### PR TITLE
Add a failing test for a destination rule raising a JobNotReadyException

### DIFF
--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -76,7 +76,9 @@ destinations:
       k8s_walltime_limit: 10
     rules:
       - if: input_size > 10
-        fail: job size too large for this destination
+        execute: |
+          from tpv.core.entities import TryNextDestination
+          raise TryNextDestination("job size too large for this destination")
     scheduling:
       prefer:
         - pulsar
@@ -92,7 +94,9 @@ destinations:
       k8s_walltime_limit: 20
     rules:
       - if: input_size > 20
-        fail: job size too large for this destination too
+        execute: |
+          from tpv.core.entities import TryNextDestination
+          raise TryNextDestination("job size too large for this destination too")
     scheduling:
       prefer:
         - pulsar

--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -69,8 +69,8 @@ destinations:
     rules:
       - if: input_size > 10
         execute: |
-          from tpv.core.entities import TryNextDestination
-          raise TryNextDestination("job size too large for this destination")
+          from tpv.core.entities import TryNextDestinationOrFail
+          raise TryNextDestinationOrFail("job size too large for this destination")
     scheduling:
       prefer:
         - pulsar

--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -5,6 +5,8 @@ tools:
   default:
     cores: 2
     mem: cores * 3
+    params:
+      nativeSpec: '--cores {cores} --mem {mem}'
     env:
       TEST_JOB_SLOTS: "{cores}"
       TEST_ENTITY_PRIORITY: "{cores}"
@@ -28,14 +30,40 @@ tools:
         - pulsar
       require:
         - inherited
+  three_core_test_tool:
+    scheduling:
+      require:
+        - local
+    rules:
+      - if: input_size > 3
+        id: arbitrary_3_core_assignment
+        cores: 3
 
 destinations:
   local:
     cores: 4
     mem: 16
     scheduling:
+      accept:
+        - local
       prefer:
         - general
+    rules:
+      - if: |
+          from tpv.core.entities import Tool
+          is_three_core_job = False
+          try:
+            [tool_entity] = list(filter(lambda x: isinstance(x, Tool), entities))
+            is_three_core_job = tool_entity.cores == 3
+          except:
+            pass # too many or too few or something, dw
+          is_three_core_job
+        id: arbitrary_3_core_avoidance
+        env:
+          OK_SO_THIS_IS_MATCHING: it_is
+        execute: |
+          from galaxy.jobs.mapper import JobNotReadyException
+          raise JobNotReadyException()
   k8s_environment:
     cores: 16
     mem: 64

--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -87,8 +87,8 @@ destinations:
     rules:
       - if: input_size > 20
         execute: |
-          from tpv.core.entities import TryNextDestination
-          raise TryNextDestination("job size too large for this destination too")
+          from tpv.core.entities import TryNextDestinationOrFail
+          raise TryNextDestinationOrFail("job size too large for this destination too")
     scheduling:
       prefer:
         - pulsar

--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -54,8 +54,8 @@ destinations:
         env:
           OK_SO_THIS_IS_MATCHING: it_is
         execute: |
-          from tpv.core.entities import WaitForDestination
-          raise WaitForDestination("Cannot run this job here at this time, may be available later, try elsewhere")
+          from tpv.core.entities import TryNextDestinationOrWait
+          raise TryNextDestinationOrWait("Cannot run this job here at this time, may be available later, try elsewhere")
   k8s_environment:
     cores: 16
     mem: 64

--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -49,16 +49,8 @@ destinations:
       prefer:
         - general
     rules:
-      - if: |
-          from tpv.core.entities import Tool
-          is_three_core_job = False
-          try:
-            [tool_entity] = list(filter(lambda x: isinstance(x, Tool), entities))
-            is_three_core_job = tool_entity.cores == 3
-          except:
-            pass # too many or too few or something, dw
-          is_three_core_job
-        id: arbitrary_3_core_avoidance
+      - id: arbitrary_3_core_avoidance
+        if: entity.cores == 3
         env:
           OK_SO_THIS_IS_MATCHING: it_is
         execute: |

--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -54,8 +54,8 @@ destinations:
         env:
           OK_SO_THIS_IS_MATCHING: it_is
         execute: |
-          from galaxy.jobs.mapper import JobNotReadyException
-          raise JobNotReadyException()
+          from tpv.core.entities import WaitForDestination
+          raise WaitForDestination("Cannot run this job here at this time, may be available later, try elsewhere")
   k8s_environment:
     cores: 16
     mem: 64

--- a/tests/test_mapper_destinations.py
+++ b/tests/test_mapper_destinations.py
@@ -73,3 +73,15 @@ class TestMapperDestinations(unittest.TestCase):
         self.assertEqual([env['value'] for env in destination.env if env['name'] == 'SPECIAL_FLAG'], ['third'])
         self.assertEqual([env['value'] for env in destination.env if env['name'] == 'DOCKER_ENABLED'], [])
         self.assertEqual(destination.params['memory_requests'], '18')
+
+    def test_destination_can_raise_not_ready_exception(self):
+        tool = mock_galaxy.Tool('three_core_test_tool')
+        user = mock_galaxy.User('tricia', 'tmcmillan@vortex.org')
+
+        config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-destinations.yml')
+
+        datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=12*1024**3))]
+        from galaxy.jobs.mapper import JobNotReadyException
+        with self.assertRaises(JobNotReadyException):
+            destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
+            print(destination)

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -48,7 +48,7 @@ class IncompatibleTagsException(Exception):
             f" {[tag.value for tag in second_set.filter(TagType.REJECT)]}.")
 
 
-class TryNextDestination(Exception):
+class TryNextDestinationOrFail(Exception):
     # Try next destination, fail job if destination options exhausted
     pass
 

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -53,7 +53,7 @@ class TryNextDestinationOrFail(Exception):
     pass
 
 
-class WaitForDestination(Exception):
+class TryNextDestinationOrWait(Exception):
     # Try next destination, raise JobNotReadyException if destination options exhausted
     pass
 

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -49,6 +49,12 @@ class IncompatibleTagsException(Exception):
 
 
 class TryNextDestination(Exception):
+    # Try next destination, fail job if destination options exhausted
+    pass
+
+
+class WaitForDestination(Exception):
+    # Try next destination, raise JobNotReadyException if destination options exhausted
     pass
 
 

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -48,6 +48,10 @@ class IncompatibleTagsException(Exception):
             f" {[tag.value for tag in second_set.filter(TagType.REJECT)]}.")
 
 
+class TryNextDestination(Exception):
+    pass
+
+
 class TagSetManager(object):
 
     def __init__(self, tags=[]):

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import re
 
-from .entities import Tool
+from .entities import Tool, TryNextDestination
 from .loader import TPVConfigLoader
 
 log = logging.getLogger(__name__)
@@ -149,8 +149,9 @@ class EntityToDestinationMapper(object):
                     final_combined_entity = dest_combined_entity.evaluate_late(context)
                     gxy_destination = app.job_config.get_destination(d.id)
                     return self.configure_gxy_destination(gxy_destination, final_combined_entity)
-                except Exception as e:
-                    log.debug(f"Destination entity: {d} matched but could not fulfill requirements due to: {e}")
+                except TryNextDestination as e:
+                    log.debug(f"Destination entity: {d} matched but could not fulfill requirements due to: {e}."
+                              " Trying next candidate...")
 
         # 8. No matching destinations. Throw an exception
         from galaxy.jobs.mapper import JobMappingException

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -152,11 +152,11 @@ class EntityToDestinationMapper(object):
                     final_combined_entity = dest_combined_entity.evaluate_late(context)
                     gxy_destination = app.job_config.get_destination(d.id)
                     return self.configure_gxy_destination(gxy_destination, final_combined_entity)
-                except (TryNextDestination, WaitForDestination) as e:
-                    log.debug(f"Destination entity: {d} matched but could not fulfill requirements due to: {e}."
+                except TryNextDestinationOrFail as ef:
+                    log.debug(f"Destination entity: {d} matched but could not fulfill requirements due to: {ef}."
                               " Trying next candidate...")
-                    if isinstance(e, WaitForDestination):
-                        wait_exception_raised = True
+                except TryNextDestinationOrWait as ew:
+                    wait_exception_raised = True
             if wait_exception_raised:
                 raise JobNotReadyException()
 

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -45,7 +45,7 @@ class EntityToDestinationMapper(object):
     def evaluate_entity_early(self, entities, entity, context):
         context.update({
             'entities': entities,
-            'entity': entity,
+            'entity': entities[0] if entities else entity,
             'self': entity
         })
         return entity.evaluate_early(context)
@@ -144,7 +144,7 @@ class EntityToDestinationMapper(object):
             for d in ranked_dest_entities:
                 try:  # An exception here signifies that a destination rule did not match
                     # Evaluate the destinations as regular entities
-                    early_evaluated_destination = self.evaluate_entity_early([d, late_evaluated_entity], d, context)
+                    early_evaluated_destination = self.evaluate_entity_early([late_evaluated_entity, d], d, context)
                     dest_combined_entity = early_evaluated_destination.combine(late_evaluated_entity)
                     final_combined_entity = dest_combined_entity.evaluate_late(context)
                     gxy_destination = app.job_config.get_destination(d.id)

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -155,7 +155,7 @@ class EntityToDestinationMapper(object):
                 except TryNextDestinationOrFail as ef:
                     log.debug(f"Destination entity: {d} matched but could not fulfill requirements due to: {ef}."
                               " Trying next candidate...")
-                except TryNextDestinationOrWait as ew:
+                except TryNextDestinationOrWait:
                     wait_exception_raised = True
             if wait_exception_raised:
                 raise JobNotReadyException()

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import re
 
-from .entities import Tool, TryNextDestination, WaitForDestination
+from .entities import Tool, TryNextDestinationOrFail, TryNextDestinationOrWait
 from .loader import TPVConfigLoader
 
 from galaxy.jobs.mapper import JobNotReadyException


### PR DESCRIPTION
Hi @nuwang, I've been testing to see how to get the cores for the job during a destination rule.  I'm pretty sure this matches but it fails the job (no destinations available) rather than raising the exception.