### PR TITLE
Add context tests for context variables accessed within rules

### DIFF
--- a/tests/fixtures/mapping-context.yml
+++ b/tests/fixtures/mapping-context.yml
@@ -33,6 +33,7 @@ tools:
   bwa:
     context:
       medium_job_cores: 5
+      large_input_size: 60
     gpus: 2
     scheduling:
       require:
@@ -40,7 +41,13 @@ tools:
     rules:
       - if: input_size <= medium_input_size
         gpus: 4
-      - if: input_size >= large_input_size
+      - if: input_size >=  large_input_size
+        fail: Too much data, shouldn't run
+  canu:
+    context:
+      smallish_input_size: 4
+    rules:
+      - if: input_size >= smallish_input_size
         fail: Too much data, shouldn't run
   trinity:
     gpus: 3

--- a/tests/test_mapper_context.py
+++ b/tests/test_mapper_context.py
@@ -2,7 +2,6 @@ import os
 import unittest
 from tpv.rules import gateway
 from . import mock_galaxy
-from tpv.core.loader import InvalidParentException
 
 
 class TestMapperContext(unittest.TestCase):
@@ -45,13 +44,13 @@ class TestMapperContext(unittest.TestCase):
         datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=40*1024**3))]
 
         destination = self._map_to_destination(tool, user, datasets)
-        self.assertEqual(destination.params['native_spec'], '--mem 15 --cores 5 --gpus 4')
+        self.assertEqual(destination.params['native_spec'], '--mem 15 --cores 5 --gpus 2')
 
     def test_context_variable_defined_for_tool_in_rule(self):
         # test that context variable set for tool entity but not set in ancestor entities is defined
         tool = mock_galaxy.Tool('canu')
         user = mock_galaxy.User('gargravarr', 'fairycake@vortex.org')
-        datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=5*1024**3))]
+        datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=3*1024**3))]
 
         destination = self._map_to_destination(tool, user, datasets)
         self.assertEqual(destination.params['native_spec'], '--mem 9 --cores 3 --gpus 1')

--- a/tests/test_mapper_context.py
+++ b/tests/test_mapper_context.py
@@ -37,3 +37,21 @@ class TestMapperContext(unittest.TestCase):
         self.assertEqual(destination.id, "k8s_environment")
         self.assertEqual([env['value'] for env in destination.env if env['name'] == 'TEST_JOB_SLOTS'], ['5'])
         self.assertEqual(destination.params['native_spec'], '--mem 15 --cores 5 --gpus 4')
+
+    def test_context_variable_overridden_in_rule(self):
+        # test that job will not fail with 40GB input size because large_input_size has been set to 60
+        tool = mock_galaxy.Tool('bwa')
+        user = mock_galaxy.User('gargravarr', 'fairycake@vortex.org')
+        datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=40*1024**3))]
+
+        destination = self._map_to_destination(tool, user, datasets)
+        self.assertEqual(destination.params['native_spec'], '--mem 15 --cores 5 --gpus 4')
+
+    def test_context_variable_defined_for_tool_in_rule(self):
+        # test that context variable set for tool entity but not set in ancestor entities is defined
+        tool = mock_galaxy.Tool('canu')
+        user = mock_galaxy.User('gargravarr', 'fairycake@vortex.org')
+        datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=5*1024**3))]
+
+        destination = self._map_to_destination(tool, user, datasets)
+        self.assertEqual(destination.params['native_spec'], '--mem 9 --cores 3 --gpus 1')

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -410,6 +410,7 @@ class EntityWithRules(Entity):
 
     def evaluate_early(self, context):
         new_entity = copy.deepcopy(self)
+        context.update(new_entity.context or {})
         for rule in self.rules.values():
             if rule.is_matching(context):
                 rule = rule.evaluate_early(context)


### PR DESCRIPTION
Two failing tests for context variables used within rules:

(1) large_input_size is set to 60 for tool bwa.  The rule will fail the job if input_size > large_input_size.  The job fails with input size 40 because it is using the parent value (20) for large_input_size.

(2) tool canu has context variable 'smallish_input_size' which does not exist on any of the ancestor entities.  At the of evaluation (early?) this variable does not exist so the job fails.

I'm not sure whether (2) should work or whether context variables must always be defined globally and then overridden.  (1) needs to work for context variables to be used in rules.