### PR TITLE
Add support for overriding destination name

### DIFF
--- a/tests/fixtures/job_conf.yml
+++ b/tests/fixtures/job_conf.yml
@@ -25,6 +25,9 @@ execution:
     inherited_k8s_environment:
       runner: k8s
       docker_enabled: true
+    custom_naming:
+      runner: k8s
+      docker_enabled: true
     tpv_dispatcher:
       runner: dynamic
       type: python

--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -38,6 +38,10 @@ tools:
       - if: input_size > 3
         id: arbitrary_3_core_assignment
         cores: 3
+  custom_tool:
+    scheduling:
+      require:
+        - custom
 
 destinations:
   local:
@@ -105,3 +109,15 @@ destinations:
     scheduling:
       require:
         - inherited
+  custom_naming:
+    cores: 16
+    mem: 64
+    gpus: 2
+    env:
+      SPECIAL_FLAG: "third"
+    params:
+      memory_requests: "{mem*3}"
+      destination_name_override: 'my-dest-with-{cores}-cores-{mem}-mem'
+    scheduling:
+      require:
+        - custom

--- a/tests/test_mapper_destinations.py
+++ b/tests/test_mapper_destinations.py
@@ -85,3 +85,14 @@ class TestMapperDestinations(unittest.TestCase):
         with self.assertRaises(JobNotReadyException):
             destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
             print(destination)
+
+    def test_custom_destination_naming(self):
+        tool = mock_galaxy.Tool('custom_tool')
+        user = mock_galaxy.User('ford', 'prefect@vortex.org')
+
+        config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-destinations.yml')
+
+        # an intermediate file size should compute correct values
+        datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=12*1024**3))]
+        destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
+        self.assertEqual(destination.id, "my-dest-with-2-cores-6-mem")

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -151,6 +151,8 @@ class EntityToDestinationMapper(object):
                     dest_combined_entity = early_evaluated_destination.combine(late_evaluated_entity)
                     final_combined_entity = dest_combined_entity.evaluate_late(context)
                     gxy_destination = app.job_config.get_destination(d.id)
+                    if final_combined_entity.params.get('destination_name_override'):
+                        gxy_destination.id = final_combined_entity.params.get('destination_name_override')
                     return self.configure_gxy_destination(gxy_destination, final_combined_entity)
                 except TryNextDestinationOrFail as ef:
                     log.debug(f"Destination entity: {d} matched but could not fulfill requirements due to: {ef}."


### PR DESCRIPTION
@cat-bro Is this what's expected with destination name overrides? The destination must still exist in job_conf though, the only difference is that a custom name can be given. We could modify it so even a job_conf entry is not required, but that seems unnecessary?

@bgruening This PR adds support for custom naming if required by Galaxy EU: https://github.com/usegalaxy-eu/sorting-hat/blob/0b0758a1b8b72bc0ea5ae198ad2949f4aa16b586/sorting_hat.py#L186