### PR TITLE
Use ruamel.yaml in tpv.core.util since PyYAML is not a dependency

### DIFF
--- a/tpv/core/util.py
+++ b/tpv/core/util.py
@@ -1,13 +1,14 @@
 import os
-import yaml
+import ruamel.yaml
 
 import requests
 
 
 def load_yaml_from_url_or_path(url_or_path: str):
+    yaml = ruamel.yaml.YAML(typ='safe')
     if os.path.isfile(url_or_path):
         with open(url_or_path, 'r') as f:
-            return yaml.safe_load(f)
+            return yaml.load(f)
     else:
         with requests.get(url_or_path) as r:
-            return yaml.safe_load(r.content)
+            return yaml.load(r.content)


### PR DESCRIPTION
Otherwise I was getting:

```pytb
Traceback (most recent call last):
  File "/home/nate/.virtualenvs/tpvdev2/bin/tpv", line 33, in <module>
    sys.exit(load_entry_point('total-perspective-vortex', 'console_scripts', 'tpv')())
  File "/home/nate/.virtualenvs/tpvdev2/bin/tpv", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/nate/work/total-perspective-vortex/tpv/core/shell.py", line 8, in <module>
    from .formatter import TPVConfigFormatter
  File "/home/nate/work/total-perspective-vortex/tpv/core/formatter.py", line 4, in <module>
    from . import util
  File "/home/nate/work/total-perspective-vortex/tpv/core/util.py", line 2, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```