### PR TITLE
Avoid deepcopying loader when cloning entities

### DIFF
--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+from tpv.rules import gateway
+from . import mock_galaxy
+
+
+class TestEntity(unittest.TestCase):
+
+    @staticmethod
+    def _map_to_destination(app, job, tool, user):
+        tpv_config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-rule-argument-based.yml')
+        gateway.ACTIVE_DESTINATION_MAPPER = None
+        return gateway.map_tool_to_destination(app, job, tool, user, tpv_config_files=[tpv_config])
+
+    # issue: https://github.com/galaxyproject/total-perspective-vortex/issues/53
+    def test_all_entities_refer_to_same_loader(self):
+        app = mock_galaxy.App()
+        job = mock_galaxy.Job()
+
+        tool = mock_galaxy.Tool('bwa')
+        user = mock_galaxy.User('ford', 'prefect@vortex.org')
+
+        # just map something so the ACTIVE_DESTINATION_MAPPER is populated
+        self._map_to_destination(app, job, tool, user)
+
+        # get the original loader
+        original_loader = gateway.ACTIVE_DESTINATION_MAPPER.loader
+
+        # make sure we are still referring to the same loader after evaluation
+        _, evaluated_entity = gateway.ACTIVE_DESTINATION_MAPPER.match_combine_evaluate_entities(app, tool, user, job)
+        assert evaluated_entity.loader == original_loader
+        for rule in evaluated_entity.rules:
+            assert rule.loader == original_loader

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -188,6 +188,19 @@ class Entity(object):
         self.context = context
         self.validate()
 
+    def __deepcopy__(self, memodict={}):
+        # make sure we don't deepcopy the loader: https://github.com/galaxyproject/total-perspective-vortex/issues/53
+        # xref: https://stackoverflow.com/a/15774013
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memodict[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k == "loader":
+                setattr(result, k, v)
+            else:
+                setattr(result, k, copy.deepcopy(v, memodict))
+        return result
+
     def process_complex_property(self, prop, context, func):
         if isinstance(prop, str):
             return func(prop, context)


### PR DESCRIPTION
Originally, the loader was not an attribute of an entity. It was added later as a performance optimization, so that all entities could share the same code cache for compiled fragments. Ironically, it has had the opposite effect, resulting in exponential memory use and increase in runtime. This is because the existing code for deep cloning was now inadvertently deep-cloning the loader too, which in turn references *all* available entities. This PR makes sure the loader attribute is shallow-copied when deep-copying entities.

Fixes: https://github.com/galaxyproject/total-perspective-vortex/issues/53