### PR TITLE
Improve formatting of entities and add more tests

### DIFF
--- a/tests/fixtures/formatter/formatter-basic.yml
+++ b/tests/fixtures/formatter/formatter-basic.yml
@@ -78,6 +78,7 @@ tools:
     rules:
       - mem: cores * 4
         if: input_size >= 0.2
+        id: my_rule_2
         cores: 16
         context:
           myvar: "test1"
@@ -95,3 +96,7 @@ tools:
           reject:
             - offline
           require:
+      - mem: cores * 4
+        if: input_size >= 0.8
+        cores: 8
+        id: my_rule_1

--- a/tests/fixtures/formatter/formatter-basic.yml
+++ b/tests/fixtures/formatter/formatter-basic.yml
@@ -52,6 +52,9 @@ tools:
         - pulsar
   base_default:
     mem: cores * 3 # note, some clusters will tolerate more than this
+    context:
+      my_context_var1: "hello"
+      another_context_var2: "world"
     cores: 1
     scheduling:
       prefer:
@@ -62,7 +65,10 @@ tools:
       require:
     params:
       nativeSpecification: "--nodes=1 --ntasks={cores} --ntasks-per-node={cores} --mem={mem*1024}"
-    env: {}
+      anotherParam: "hello"
+    env:
+      some_env: "1"
+      another_env: "1"
     rules: []
   '.*hifiasm.*':
     cores: 2
@@ -70,5 +76,22 @@ tools:
       prefer:
         - pulsar
     rules:
-      - if: input_size >= 0.2
+      - mem: cores * 4
+        if: input_size >= 0.2
         cores: 16
+        context:
+          myvar: "test1"
+          anothervar: "test2"
+        params:
+          MY_PARAM2: "2"
+          MY_PARAM1: "1"
+        env:
+          SOME_ENV2: "2"
+          SOME_ENV1: "1"
+        scheduling:
+          accept:
+            - general
+          prefer:
+          reject:
+            - offline
+          require:

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -86,15 +86,21 @@ class TPVShellTestCase(unittest.TestCase):
 
         # context var order should not be changed
         self.assertEqual(list(before_formatting['tools']['base_default']['context'].keys()),
+                         ['my_context_var1', 'another_context_var2'])
+        self.assertEqual(list(before_formatting['tools']['base_default']['context'].keys()),
                          list(after_formatting['tools']['base_default']['context'].keys()))
 
-        # params order should not be changed
+        # params should be in alphabetical order
         self.assertEqual(list(before_formatting['tools']['base_default']['params'].keys()),
-                         list(after_formatting['tools']['base_default']['params'].keys()))
+                         ['nativeSpecification', 'anotherParam'])
+        self.assertEqual(list(after_formatting['tools']['base_default']['params'].keys()),
+                         ['anotherParam', 'nativeSpecification'])
 
-        # env order should not be changed
+        # env should be in alphabetical order
         self.assertEqual(list(before_formatting['tools']['base_default']['env'].keys()),
-                         list(after_formatting['tools']['base_default']['env'].keys()))
+                         ['some_env', 'another_env'])
+        self.assertEqual(list(after_formatting['tools']['base_default']['env'].keys()),
+                         ['another_env', 'some_env'])
 
     def test_format_rules(self):
         tpv_config = os.path.join(os.path.dirname(__file__), 'fixtures/formatter/formatter-basic.yml')
@@ -118,15 +124,21 @@ class TPVShellTestCase(unittest.TestCase):
 
         # context var order should not be changed
         self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0]['context'].keys()),
+                         ['myvar', 'anothervar'])
+        self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0]['context'].keys()),
                          list(after_formatting['tools']['.*hifiasm.*']['rules'][0]['context'].keys()))
 
         # params order should not be changed
         self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0]['params'].keys()),
-                         list(after_formatting['tools']['.*hifiasm.*']['rules'][0]['params'].keys()))
+                         ['MY_PARAM2', 'MY_PARAM1'])
+        self.assertEqual(list(after_formatting['tools']['.*hifiasm.*']['rules'][0]['params'].keys()),
+                         ['MY_PARAM1', 'MY_PARAM2'])
 
         # env order should not be changed
         self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0]['env'].keys()),
-                         list(after_formatting['tools']['.*hifiasm.*']['rules'][0]['env'].keys()))
+                         ['SOME_ENV2', 'SOME_ENV1'])
+        self.assertEqual(list(after_formatting['tools']['.*hifiasm.*']['rules'][0]['env'].keys()),
+                         ['SOME_ENV1', 'SOME_ENV2'])
 
     def test_format_error(self):
         tpv_config = os.path.join(os.path.dirname(__file__), 'fixtures/file-does-not-exist.yml')

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -78,11 +78,55 @@ class TPVShellTestCase(unittest.TestCase):
         self.assertEqual(list(before_formatting['destinations']).index('base_default'), 2)
         self.assertEqual(list(after_formatting['destinations']).index('base_default'), 0)
 
-        # nested keys should be in expected order
+        # scheduling tags should be in expected order
         self.assertEqual(list(before_formatting['tools']['base_default']['scheduling'].keys()),
                          ["prefer", "accept", "reject", "require"])
         self.assertEqual(list(after_formatting['tools']['base_default']['scheduling'].keys()),
                          ["require", "prefer", "accept", "reject"])
+
+        # context var order should not be changed
+        self.assertEqual(list(before_formatting['tools']['base_default']['context'].keys()),
+                         list(after_formatting['tools']['base_default']['context'].keys()))
+
+        # params order should not be changed
+        self.assertEqual(list(before_formatting['tools']['base_default']['params'].keys()),
+                         list(after_formatting['tools']['base_default']['params'].keys()))
+
+        # env order should not be changed
+        self.assertEqual(list(before_formatting['tools']['base_default']['env'].keys()),
+                         list(after_formatting['tools']['base_default']['env'].keys()))
+
+    def test_format_rules(self):
+        tpv_config = os.path.join(os.path.dirname(__file__), 'fixtures/formatter/formatter-basic.yml')
+        with open(tpv_config) as f:
+            before_formatting = yaml.safe_load(f)
+
+        output = self.call_shell_command("tpv", "format", tpv_config)
+        after_formatting = yaml.safe_load(output)
+
+        # rules should be in expected order
+        self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0].keys()),
+                         ['mem', 'if', 'cores', 'context', 'params', 'env', 'scheduling'])
+        self.assertEqual(list(after_formatting['tools']['.*hifiasm.*']['rules'][0].keys()),
+                         ['if', 'context', 'cores', 'mem', 'env', 'params', 'scheduling'])
+
+        # scheduling tags within rules should be in expected order
+        self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0]['scheduling'].keys()),
+                         ['accept', 'prefer', 'reject', 'require'])
+        self.assertEqual(list(after_formatting['tools']['.*hifiasm.*']['rules'][0]['scheduling'].keys()),
+                         ["require", "prefer", "accept", "reject"])
+
+        # context var order should not be changed
+        self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0]['context'].keys()),
+                         list(after_formatting['tools']['.*hifiasm.*']['rules'][0]['context'].keys()))
+
+        # params order should not be changed
+        self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0]['params'].keys()),
+                         list(after_formatting['tools']['.*hifiasm.*']['rules'][0]['params'].keys()))
+
+        # env order should not be changed
+        self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0]['env'].keys()),
+                         list(after_formatting['tools']['.*hifiasm.*']['rules'][0]['env'].keys()))
 
     def test_format_error(self):
         tpv_config = os.path.join(os.path.dirname(__file__), 'fixtures/file-does-not-exist.yml')

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -110,11 +110,17 @@ class TPVShellTestCase(unittest.TestCase):
         output = self.call_shell_command("tpv", "format", tpv_config)
         after_formatting = yaml.safe_load(output)
 
-        # rules should be in expected order
+        # rules should remain in original order
+        self.assertEqual(before_formatting['tools']['.*hifiasm.*']['rules'][0]['id'], "my_rule_2")
+        self.assertEqual(after_formatting['tools']['.*hifiasm.*']['rules'][0]['id'], "my_rule_2")
+        self.assertEqual(before_formatting['tools']['.*hifiasm.*']['rules'][1]['id'], "my_rule_1")
+        self.assertEqual(after_formatting['tools']['.*hifiasm.*']['rules'][1]['id'], "my_rule_1")
+
+        # rule elements should be in expected order
         self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0].keys()),
-                         ['mem', 'if', 'cores', 'context', 'params', 'env', 'scheduling'])
+                         ['mem', 'if', 'id', 'cores', 'context', 'params', 'env', 'scheduling'])
         self.assertEqual(list(after_formatting['tools']['.*hifiasm.*']['rules'][0].keys()),
-                         ['if', 'context', 'cores', 'mem', 'env', 'params', 'scheduling'])
+                         ['id', 'if', 'context', 'cores', 'mem', 'env', 'params', 'scheduling'])
 
         # scheduling tags within rules should be in expected order
         self.assertEqual(list(before_formatting['tools']['.*hifiasm.*']['rules'][0]['scheduling'].keys()),

--- a/tpv/core/formatter.py
+++ b/tpv/core/formatter.py
@@ -70,9 +70,8 @@ class TPVConfigFormatter(object):
                                                                     sort_order.get(key, {}) or sort_order.get('*', {}))
                     for key in sorted_keys}
         elif isinstance(dict_to_sort, list):
-            sorted_items = sorted(dict_to_sort or [], key=TPVConfigFormatter.generic_key_sorter(sort_order.keys()))
             return [TPVConfigFormatter.multi_level_dict_sorter(item, sort_order.get('*', []))
-                    for item in sorted_items]
+                    for item in dict_to_sort]
         else:
             return dict_to_sort
 
@@ -80,6 +79,7 @@ class TPVConfigFormatter(object):
         default_inherits = self.yaml_dict.get('global', {}).get('default_inherits') or 'default'
 
         basic_entity_sort_order = {
+            'id': {},
             'if': {},
             'context': {},
             'gpus': {},

--- a/tpv/core/formatter.py
+++ b/tpv/core/formatter.py
@@ -85,8 +85,12 @@ class TPVConfigFormatter(object):
             'gpus': {},
             'cores': {},
             'mem': {},
-            'env': {},
-            'params': {},
+            'env': {
+                '*': {}
+            },
+            'params': {
+                '*': {}
+            },
             'scheduling': {
                 'require': {},
                 'prefer': {},


### PR DESCRIPTION
This PR makes the following improvements to the formatter.

1. Fields within rules are also formatted in the same order
2. Context vars are not sorted. They appear in their original order.
3. Params and envs are sorted alphabetically.
4. users now appear after roles, but before destinations.