### PR TITLE
Fix missing app.config.is_set() in mock config for dry-run

### DIFF
--- a/tpv/core/test/mock_galaxy.py
+++ b/tpv/core/test/mock_galaxy.py
@@ -61,6 +61,7 @@ class App:
             default_job_resubmission_condition="",
             track_jobs_in_database=True,
             server_name="main",
+            is_set=lambda x: True,
         )
         self.application_stack = ApplicationStack()
         self.job_metrics = JobMetrics()


### PR DESCRIPTION
Fixes #71.

I can't say that `True` will always be the right answer but it works for the specific issue encountered.