### PR TITLE
Add helper for checking entity tags within a tpv rule

### DIFF
--- a/tests/fixtures/mapping-role.yml
+++ b/tests/fixtures/mapping-role.yml
@@ -9,16 +9,23 @@ tools:
       TOOL_AND_ROLE_DEFINED: "tool"
       TOOL_AND_USER_DEFINED: "tool"
       TOOL_USER_AND_ROLE_DEFINED: "tool"
+    params:
+      native_spec: '--mem {mem} --cores {cores}'
     scheduling:
       require: []
       prefer:
         - general
-      accept:
-      reject:
-        - pulsar
     rules: []
   bwa:
     scheduling:
+      require:
+        - pulsar
+  flye:
+    cores: 6
+    mem: 12
+    scheduling:
+      accept:
+        - pulsar-training-large
       require:
         - pulsar
 users:
@@ -60,14 +67,12 @@ roles:
     max_cores: 8
     max_mem: 8
     env: []
-    scheduling:
-      require:
-        - general
     rules: []
   training:
     scheduling:
       require:
         - pulsar
+        - general
   newtraining2021.*:
     env:
       TOOL_AND_ROLE_DEFINED: "role"
@@ -78,7 +83,20 @@ roles:
         - pulsar
       reject:
         - general
-
+  seminar-ga:
+    rules:
+      - id: default_training_rule
+        if: helpers.tag_values_match(entity, match_tag_values=[], exclude_tag_values=['pulsar'])
+        max_cores: 1
+        max_mem: 1
+      - id: small_pulsar_training_rule
+        if: helpers.tag_values_match(entity, match_tag_values=['pulsar'], exclude_tag_values=['pulsar-training-large'])
+        max_cores: 2
+        max_mem: 2
+      - id: large_pulsar_training_rule
+        if: helpers.tag_values_match(entity, match_tag_values=['pulsar-training-large'], exclude_tag_values=[])
+        max_cores: 3
+        max_mem: 3
 destinations:
   local:
     runner: local

--- a/tests/test_mapper_role.py
+++ b/tests/test_mapper_role.py
@@ -48,3 +48,21 @@ class TestMapperRole(unittest.TestCase):
                          ['user'])
         self.assertEqual([env['value'] for env in destination.env if env['name'] == 'USER_AND_ROLE_DEFINED'],
                          ['user'])
+
+    def test_map_role_training_matching_tag_values(self):
+        user = mock_galaxy.User('trin', 'tragula@perspective.org', roles=["seminar-ga"])
+
+        # test default training rule
+        tool = mock_galaxy.Tool('quast')
+        destination = self._map_to_destination(tool, user)
+        self.assertEqual(destination.params['native_spec'], '--mem 1 --cores 1')
+
+        # test training small pulsar rule
+        tool = mock_galaxy.Tool('bwa')
+        destination = self._map_to_destination(tool, user)
+        self.assertEqual(destination.params['native_spec'], '--mem 2 --cores 2')
+
+        # test default training large pulsar rule
+        tool = mock_galaxy.Tool('flye')
+        destination = self._map_to_destination(tool, user)
+        self.assertEqual(destination.params['native_spec'], '--mem 3 --cores 3')

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -82,10 +82,6 @@ def tag_values_match(entity, match_tag_values=[], exclude_tag_values=[]):
     # Return true if an entity has require/prefer/accept tags in the match_tags_values list
     # and no require/prefer/accept tags in the exclude_tag_values list
     return (
-        all([any(entity.tpv_tags.filter(tag_value=tag_value))
-            for tag_value in match_tag_values]
-        ) and not any(
-            [any(entity.tpv_tags.filter(tag_value=tag_value))
-            for tag_value in exclude_tag_values]
-        )
+        all([any(entity.tpv_tags.filter(tag_value=tag_value)) for tag_value in match_tag_values])
+        and not any([any(entity.tpv_tags.filter(tag_value=tag_value)) for tag_value in exclude_tag_values])
     )

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -76,3 +76,16 @@ def concurrent_job_count_for_tool(app, tool, user=None):  # requires galaxy vers
     query = query.filter(model.Job.table.c.state.in_(['queued', 'running']))
     query = query.filter(model.Job.table.c.tool_id.regexp_match(tool_id_regex))
     return query.count()
+
+
+def tag_values_match(entity, match_tag_values=[], exclude_tag_values=[]):
+    # Return true if an entity has require/prefer/accept tags in the match_tags_values list
+    # and no require/prefer/accept tags in the exclude_tag_values list
+    return (
+        all([any(entity.tpv_tags.filter(tag_value=tag_value))
+            for tag_value in match_tag_values]
+        ) and not any(
+            [any(entity.tpv_tags.filter(tag_value=tag_value))
+            for tag_value in exclude_tag_values]
+        )
+    )


### PR DESCRIPTION
Add a helper that takes an entity and two lists of tags, one to match and one to exclude. Returns true if the entity has every tag from the include list and no tags from the exclude list.

This is useful for a Galaxy Australia training rule that uses tool tags in deciding resource allocations for training jobs.