### PR TITLE
If a tool has file size rules, a role rule has no access to tool's scheduling tags

### DIFF
--- a/tests/fixtures/mapping-role.yml
+++ b/tests/fixtures/mapping-role.yml
@@ -28,6 +28,23 @@ tools:
         - pulsar-training-large
       require:
         - pulsar
+  fastqc:
+    cores: 8
+    mem: 30.7
+    env:
+      _JAVA_OPTIONS: -Xmx{int(mem)}G -Xms1G
+    scheduling:
+      require:
+      - pulsar
+    rules:
+    - id: fastqc_small_input_rule
+      if: input_size < 0.01
+      cores: 2
+      mem: 7.6
+    - id: fastqc_medium_input_rule
+      if: 0.01 <= input_size < 2
+      cores: 4
+      mem: 15.3
 users:
   default:
     max_cores: 3

--- a/tests/test_mapper_role.py
+++ b/tests/test_mapper_role.py
@@ -58,7 +58,7 @@ class TestMapperRole(unittest.TestCase):
         self.assertEqual(destination.params['native_spec'], '--mem 1 --cores 1')
 
         # test training small pulsar rule
-        tool = mock_galaxy.Tool('bwa')
+        tool = mock_galaxy.Tool('fastqc')
         destination = self._map_to_destination(tool, user)
         self.assertEqual(destination.params['native_spec'], '--mem 2 --cores 2')
 

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -484,14 +484,14 @@ class EntityWithRules(Entity):
         for rule in self.rules.values():
             if rule.is_matching(context):
                 rule = rule.evaluate(context)
-                context.update({
-                    'entity': rule
-                })
                 new_entity = rule.inherit(new_entity)
                 new_entity.gpus = rule.gpus or self.gpus
                 new_entity.cores = rule.cores or self.cores
                 new_entity.mem = rule.mem or self.mem
                 new_entity.id = f"{new_entity.id}, Rule: {rule.id}"
+                context.update({
+                    'entity': new_entity
+                })
         return super(EntityWithRules, new_entity).evaluate(context)
 
     def __repr__(self):


### PR DESCRIPTION
Broken test PR

Role rules no longer have access to the tool tags and tool ID. These are some prints from running the test of the role rule helper with a tool that has tool rules. In TPV v1 we were able to access the scheduling tags for the tool being used in these rules.

```
evaluating default_training_rule:
entity: <class 'tpv.core.entities.Rule'> id=fastqc_small_input_rule, abstract=False, cores=2, mem=7.6, gpus=None, min_cores = None, min_mem = None, min_gpus = None, max_cores = None, max_mem = None, max_gpus = None, env=None, params=None, resubmit=None, tags=<class 'tpv.core.entities.TagSetManager'> tags=[], rank=, inherits=None, context=None, if=input_size, execute=, fail=
entity.tpv_tags: <class 'tpv.core.entities.TagSetManager'> tags=[]
postive tag condition: True
negative tag condition: True

evaluating small_pulsar_training_rule:
entity: <class 'tpv.core.entities.Rule'> id=default_training_rule, abstract=False, cores=None, mem=None, gpus=None, min_cores = None, min_mem = None, min_gpus = None, max_cores = 1, max_mem = 1, max_gpus = None, env=None, params=None, resubmit=None, tags=<class 'tpv.core.entities.TagSetManager'> tags=[], rank=, inherits=None, context=None, if=test_log=', execute=, fail=
entity.tpv_tags: <class 'tpv.core.entities.TagSetManager'> tags=[]
postive tag condition: False
negative tag condition: True

evaluating large_pulsar_training_rule:
entity: <class 'tpv.core.entities.Rule'> id=default_training_rule, abstract=False, cores=None, mem=None, gpus=None, min_cores = None, min_mem = None, min_gpus = None, max_cores = 1, max_mem = 1, max_gpus = None, env=None, params=None, resubmit=None, tags=<class 'tpv.core.entities.TagSetManager'> tags=[], rank=, inherits=None, context=None, if=test_log=', execute=, fail=
entity.tpv_tags: <class 'tpv.core.entities.TagSetManager'> tags=[]
postive tag condition: False
negative tag condition: True

```