### PR TITLE
Add helpers for tool version comparison

### DIFF
--- a/tests/fixtures/mapping-rule-tool-limits.yml
+++ b/tests/fixtures/mapping-rule-tool-limits.yml
@@ -26,7 +26,20 @@ tools:
         execute: |
           from galaxy.jobs.mapper import JobNotReadyException
           raise JobNotReadyException()
-
+  toolshed.g2.bx.psu.edu/repos/iuc/trinity/trinity/.*:
+    rules:
+      - if: helpers.tool_version_gte(tool, '2.15.1+galaxy0')
+        env:
+          version_gte_2.15.1+galaxy0: true
+      - if: helpers.tool_version_gt(tool, '2.15.1+galaxy0')
+        env:
+          version_gt_2.15.1+galaxy0: true
+      - if: helpers.tool_version_lt(tool, '2.10.1+galaxy7')
+        env:
+          version_lt_2.10.1+galaxy7: true
+      - if: helpers.tool_version_lte(tool, '2.10.1+galaxy7')
+        env:
+          version_lte_2.10.1+galaxy7: true
 
 destinations:
   local:

--- a/tpv/commands/test/mock_galaxy.py
+++ b/tpv/commands/test/mock_galaxy.py
@@ -44,9 +44,10 @@ class Dataset:
 
 # Tool mock and helpers=========================================
 class Tool:
-    def __init__(self, id):
+    def __init__(self, id, version=None):
         self.id = id
         self.old_id = id
+        self.version = version
         self.installed_tool_dependencies = []
 
 

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -1,3 +1,4 @@
+import packaging.version
 import random
 from functools import reduce
 from galaxy import model
@@ -85,3 +86,19 @@ def tag_values_match(entity, match_tag_values=[], exclude_tag_values=[]):
         all([any(entity.tpv_tags.filter(tag_value=tag_value)) for tag_value in match_tag_values])
         and not any([any(entity.tpv_tags.filter(tag_value=tag_value)) for tag_value in exclude_tag_values])
     )
+
+
+def tool_version_lte(tool, version):
+    return packaging.version.parse(tool.version) <= packaging.version.parse(version)
+
+
+def tool_version_lt(tool, version):
+    return packaging.version.parse(tool.version) < packaging.version.parse(version)
+
+
+def tool_version_gte(tool, version):
+    return packaging.version.parse(tool.version) >= packaging.version.parse(version)
+
+
+def tool_version_gt(tool, version):
+    return packaging.version.parse(tool.version) > packaging.version.parse(version)


### PR DESCRIPTION
Add a helpers to make it easier to reason about tool versions. Currently this is cumbersome, see https://github.com/usegalaxy-au/infrastructure/blob/master/files/galaxy/dynamic_job_rules/production/total_perspective_vortex/tools.yml#L652-L655