### PR TITLE
Failing test for pulsar user scenario

### DIFF
--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -34,7 +34,7 @@ at each destination (optional). The tools are matched by tool id, and can be a r
 resource requirements can also be computed as python expressions. If resource requirements are defined at the
 destination, TPV will check whether the job will fit. For example, hisat2 will not schedule on `general_pulsar_1`
 as it has insufficient cores. If resource requirements are omitted in the tool or destination, it is considered a match.
-Note that TPV only considers destinations defined in its own config file, and ignore destinations in job_conf.yml.
+Note that TPV only considers destinations defined in its own config file, and ignores destinations in job_conf.yml.
 
 Default inheritance
 -------------------

--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -19,6 +19,7 @@ tools:
       accept:
       reject:
         - pulsar
+        - offline
     rules:
       - if: input_size < 2
         fail: Data size too small
@@ -99,6 +100,14 @@ tools:
     scheduling:
       require:
         - test_of_min_mem_accepted
+
+users:
+  pulsar_canberra_user@act.au:
+    scheduling:
+      accept:
+        - offline
+      require:
+        - pulsar-canberra
 
 destinations:
   local:
@@ -240,3 +249,8 @@ destinations:
     scheduling:
       require:
         - test_of_min_mem_accepted
+  pulsar-canberra:
+    runner: k8s
+    scheduling:
+      accept:
+        - pulsar-canberra

--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -27,6 +27,11 @@ tools:
     scheduling:
       require:
         - pulsar
+  toolshed_hifiasm:
+    cores: 1000
+    rules:
+      - if: input_size < 1000
+        cores: 2
   inheritance_test_tool:
     scheduling:
       accept:
@@ -103,11 +108,15 @@ tools:
 
 users:
   pulsar_canberra_user@act.au:
-    scheduling:
-      accept:
-        - offline
-      require:
-        - pulsar-canberra
+      rules:
+        - id: pulsar_user_mapping_rule
+          if: tool.id.startswith('toolshed') or tool.id.startswith('testtoolshed')
+          scheduling:
+            accept:
+              - pulsar # pulsar must be in require/prefer/accept for a job to be scheduled to pulsar
+              - offline # allow scheduling to a destination even when it is offline
+            require:
+              - pulsar-canberra
 
 destinations:
   local:
@@ -251,6 +260,7 @@ destinations:
         - test_of_min_mem_accepted
   pulsar-canberra:
     runner: k8s
+    max_accepted_cores: 32
     scheduling:
       accept:
         - pulsar-canberra

--- a/tests/test_mapper_destinations.py
+++ b/tests/test_mapper_destinations.py
@@ -182,9 +182,9 @@ class TestMapperDestinations(unittest.TestCase):
 
         config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-destinations.yml')
 
-        tool = mock_galaxy.Tool('some_assembler')
+        tool = mock_galaxy.Tool('toolshed_hifiasm')
         datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=12 * 1024 ** 3))]
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "pulsar-canberra")
-       
+        self.assertEqual(destination.params['yes_cat'], 'really')       
         

--- a/tests/test_mapper_destinations.py
+++ b/tests/test_mapper_destinations.py
@@ -186,5 +186,3 @@ class TestMapperDestinations(unittest.TestCase):
         datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=12 * 1024 ** 3))]
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "pulsar-canberra")
-        self.assertEqual(destination.params['yes_cat'], 'really')       
-        

--- a/tests/test_mapper_destinations.py
+++ b/tests/test_mapper_destinations.py
@@ -176,3 +176,15 @@ class TestMapperDestinations(unittest.TestCase):
         tool = mock_galaxy.Tool('tool_for_testing_min_mem_acceptance_match')
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "destination_with_min_mem_accepted")
+
+    def test_user_map_to_destination_accepting_offline(self):
+        user = mock_galaxy.User('albo', 'pulsar_canberra_user@act.au')
+
+        config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-destinations.yml')
+
+        tool = mock_galaxy.Tool('some_assembler')
+        datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=12 * 1024 ** 3))]
+        destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
+        self.assertEqual(destination.id, "pulsar-canberra")
+       
+        

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -485,9 +485,9 @@ class EntityWithRules(Entity):
             if rule.is_matching(context):
                 rule = rule.evaluate(context)
                 new_entity = rule.inherit(new_entity)
-                new_entity.gpus = rule.gpus or self.gpus
-                new_entity.cores = rule.cores or self.cores
-                new_entity.mem = rule.mem or self.mem
+                new_entity.gpus = rule.gpus or new_entity.gpus
+                new_entity.cores = rule.cores or new_entity.cores
+                new_entity.mem = rule.mem or new_entity.mem
                 new_entity.id = f"{new_entity.id}, Rule: {rule.id}"
                 context.update({
                     'entity': new_entity


### PR DESCRIPTION
If the user has rules, the entity is deemed to have too large a requirement for cores/RAM to run, even though toolshed_hifiasm will run with 2 cores for a job with <1TB input size.