### PR TITLE
Match cores, mem and gpus whenever they are defined

### DIFF
--- a/tests/fixtures/mapping-destinations.yml
+++ b/tests/fixtures/mapping-destinations.yml
@@ -63,48 +63,69 @@ tools:
       require:
         - something_abstract
         - also_concrete
-  tool_for_testing_min_cpu_acceptance_non_match:
+  tool_for_testing_cpu_acceptance_non_match:
     cores: 15
     mem: 53
     gpus: 2
     scheduling:
       require:
-        - test_of_min_cpu_accepted
-  tool_for_testing_min_gpu_acceptance_non_match:
+        - test_of_cpu_accepted
+  tool_for_testing_gpu_acceptance_non_match:
     cores: 15
     mem: 53
     gpus: 1
     scheduling:
       require:
-        - test_of_min_gpu_accepted
-  tool_for_testing_min_mem_acceptance_non_match:
+        - test_of_gpu_accepted
+  tool_for_testing_mem_acceptance_non_match:
     cores: 15
     mem: 53
     gpus: 2
     scheduling:
       require:
-        - test_of_min_mem_accepted
-  tool_for_testing_min_cpu_acceptance_match:
+        - test_of_mem_accepted
+  tool_for_testing_cpu_acceptance_match:
     cores: 17
     mem: 68
     gpus: 2
     scheduling:
       require:
-        - test_of_min_cpu_accepted
-  tool_for_testing_min_gpu_acceptance_match:
+        - test_of_cpu_accepted
+  tool_for_testing_gpu_acceptance_match:
     cores: 17
     mem: 68
     gpus: 2
     scheduling:
       require:
-        - test_of_min_gpu_accepted
-  tool_for_testing_min_mem_acceptance_match:
+        - test_of_gpu_accepted
+  tool_for_testing_mem_acceptance_match:
     cores: 17
     mem: 68
     gpus: 2
     scheduling:
       require:
-        - test_of_min_mem_accepted
+        - test_of_mem_accepted
+  tool_for_testing_cpu_acceptance_zero:
+    cores: 0
+    mem: 53
+    gpus: 2
+    scheduling:
+      require:
+        - test_of_cpu_accepted
+  tool_for_testing_gpu_acceptance_zero:
+    cores: 17
+    mem: 68
+    gpus: 0
+    scheduling:
+      require:
+        - test_of_gpu_accepted
+  tool_for_testing_mem_acceptance_zero:
+    cores: 15
+    mem: 0
+    gpus: 2
+    scheduling:
+      require:
+        - test_of_mem_accepted
 
 users:
   pulsar_canberra_user@act.au:
@@ -229,35 +250,53 @@ destinations:
     min_accepted_gpus: 2
     scheduling:
       require:
-        - test_of_min_cpu_accepted
+        - test_of_cpu_accepted
   destination_without_min_cpu_accepted:
     runner: k8s
     scheduling:
       require:
-        - test_of_min_cpu_accepted
+        - test_of_cpu_accepted
+  destination_zero_max_cpu_accepted:
+    runner: k8s
+    max_accepted_cores: 0
+    scheduling:
+      require:
+        - test_of_cpu_accepted
   destination_with_min_gpu_accepted:
     runner: k8s
     min_accepted_gpus: 2
     scheduling:
       require:
-        - test_of_min_gpu_accepted
+        - test_of_gpu_accepted
   destination_without_min_gpu_accepted:
     runner: k8s
     scheduling:
       require:
-        - test_of_min_gpu_accepted
+        - test_of_gpu_accepted
+  destination_zero_max_gpu_accepted:
+    runner: k8s
+    max_accepted_gpus: 0
+    scheduling:
+      require:
+        - test_of_gpu_accepted
   destination_with_min_mem_accepted:
     runner: k8s
     min_accepted_mem: 64
     min_accepted_gpus: 2
     scheduling:
       require:
-        - test_of_min_mem_accepted
+        - test_of_mem_accepted
   destination_without_min_mem_accepted:
     runner: k8s
     scheduling:
       require:
-        - test_of_min_mem_accepted
+        - test_of_mem_accepted
+  destination_zero_max_mem_accepted:
+    runner: k8s
+    max_accepted_mem: 0
+    scheduling:
+      require:
+        - test_of_mem_accepted
   pulsar-canberra:
     runner: k8s
     max_accepted_cores: 32

--- a/tests/test_mapper_destinations.py
+++ b/tests/test_mapper_destinations.py
@@ -132,50 +132,71 @@ class TestMapperDestinations(unittest.TestCase):
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "my_concrete_destination")
 
-    def test_min_accepted_cpus_honoured(self):
+    def test_accepted_cpus_honoured(self):
         user = mock_galaxy.User('toolmatchuser', 'toolmatchuser@vortex.org')
         config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-destinations.yml')
         datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=12 * 1024 ** 3))]
 
         # First tool should not match
-        tool = mock_galaxy.Tool('tool_for_testing_min_cpu_acceptance_non_match')
+        tool = mock_galaxy.Tool('tool_for_testing_cpu_acceptance_non_match')
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "destination_without_min_cpu_accepted")
 
         # second tool should match the min requirements for the destination
-        tool = mock_galaxy.Tool('tool_for_testing_min_cpu_acceptance_match')
+        tool = mock_galaxy.Tool('tool_for_testing_cpu_acceptance_match')
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "destination_with_min_cpu_accepted")
 
-    def test_min_accepted_gpus_honoured(self):
+        # third tool requesting zero cpus should match either:
+        # - destination_without_min_cpu_accepted
+        # - destination_zero_max_cpu_accepted
+        tool = mock_galaxy.Tool('tool_for_testing_cpu_acceptance_zero')
+        destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
+        self.assertIn(destination.id, {"destination_without_min_cpu_accepted", "destination_zero_max_cpu_accepted"})
+
+    def test_accepted_gpus_honoured(self):
         user = mock_galaxy.User('toolmatchuser', 'toolmatchuser@vortex.org')
         config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-destinations.yml')
         datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=12 * 1024 ** 3))]
 
         # First tool should not match
-        tool = mock_galaxy.Tool('tool_for_testing_min_gpu_acceptance_non_match')
+        tool = mock_galaxy.Tool('tool_for_testing_gpu_acceptance_non_match')
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "destination_without_min_gpu_accepted")
 
         # second tool should match the min requirements for the destination
-        tool = mock_galaxy.Tool('tool_for_testing_min_gpu_acceptance_match')
+        tool = mock_galaxy.Tool('tool_for_testing_gpu_acceptance_match')
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "destination_with_min_gpu_accepted")
 
-    def test_min_accepted_mem_honoured(self):
+        # third tool requesting zero gpus should match either:
+        # - destination_without_min_gpu_accepted
+        # - destination_zero_max_gpu_accepted
+        tool = mock_galaxy.Tool('tool_for_testing_gpu_acceptance_zero')
+        destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
+        self.assertIn(destination.id, {"destination_without_min_gpu_accepted", "destination_zero_max_gpu_accepted"})
+
+    def test_accepted_mem_honoured(self):
         user = mock_galaxy.User('toolmatchuser', 'toolmatchuser@vortex.org')
         config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-destinations.yml')
         datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=12 * 1024 ** 3))]
 
         # First tool should not match
-        tool = mock_galaxy.Tool('tool_for_testing_min_mem_acceptance_non_match')
+        tool = mock_galaxy.Tool('tool_for_testing_mem_acceptance_non_match')
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "destination_without_min_mem_accepted")
 
         # second tool should match the min requirements for the destination
-        tool = mock_galaxy.Tool('tool_for_testing_min_mem_acceptance_match')
+        tool = mock_galaxy.Tool('tool_for_testing_mem_acceptance_match')
         destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
         self.assertEqual(destination.id, "destination_with_min_mem_accepted")
+
+        # third tool requesting zero mem should match either:
+        # - destination_without_min_mem_accepted
+        # - destination_zero_max_mem_accepted
+        tool = mock_galaxy.Tool('tool_for_testing_mem_acceptance_zero')
+        destination = self._map_to_destination(tool, user, datasets, tpv_config_paths=[config])
+        self.assertIn(destination.id, {"destination_without_min_mem_accepted", "destination_zero_max_mem_accepted"})
 
     def test_user_map_to_destination_accepting_offline(self):
         user = mock_galaxy.User('albo', 'pulsar_canberra_user@act.au')

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -642,17 +642,17 @@ class Destination(EntityWithRules):
         """
         if self.abstract:
             return False
-        if self.max_accepted_cores and entity.cores and self.max_accepted_cores < entity.cores:
+        if self.max_accepted_cores is not None and entity.cores is not None and self.max_accepted_cores < entity.cores:
             return False
-        if self.max_accepted_mem and entity.mem and self.max_accepted_mem < entity.mem:
+        if self.max_accepted_mem is not None and entity.mem is not None and self.max_accepted_mem < entity.mem:
             return False
-        if self.max_accepted_gpus and entity.gpus and self.max_accepted_gpus < entity.gpus:
+        if self.max_accepted_gpus is not None and entity.gpus is not None and self.max_accepted_gpus < entity.gpus:
             return False
-        if self.min_accepted_cores and entity.cores and self.min_accepted_cores > entity.cores:
+        if self.min_accepted_cores is not None and entity.cores is not None and self.min_accepted_cores > entity.cores:
             return False
-        if self.min_accepted_mem and entity.mem and self.min_accepted_mem > entity.mem:
+        if self.min_accepted_mem is not None and entity.mem is not None and self.min_accepted_mem > entity.mem:
             return False
-        if self.min_accepted_gpus and entity.gpus and self.min_accepted_gpus > entity.gpus:
+        if self.min_accepted_gpus is not None and entity.gpus is not None and self.min_accepted_gpus > entity.gpus:
             return False
         return entity.tpv_tags.match(self.tpv_dest_tags or {})
 


### PR DESCRIPTION
The current code does not cover the case when they are defined to be zero.

Let's see whether this small change passes the tests. If it does then it gives usegalaxy.eu a chance to fix GPU scheduling using rules in a kind of ugly but not horrible way.