### PR TITLE
Swap rule execution order: apply specific rules before general rules

### DIFF
--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -471,8 +471,8 @@ class EntityWithRules(Entity):
 
     def override(self, entity):
         new_entity = super().override(entity)
-        new_entity.rules = copy.deepcopy(entity.rules)
-        new_entity.rules.update(self.rules or {})
+        new_entity.rules = copy.deepcopy(self.rules)
+        new_entity.rules.update(entity.rules or {})
         for rule in self.rules.values():
             if entity.rules.get(rule.id):
                 new_entity.rules[rule.id] = rule.inherit(entity.rules[rule.id])


### PR DESCRIPTION
The current behavior is: whenever entity B inherits from entity A, rules defined for A are executed before rules defined for B.

The new behavior is: whenever entity B inherits from entity A, rules defined for B are executed before rules defined for A.