### PR TITLE
Fix get_dataset_size for datasets with null file_size column

### DIFF
--- a/tpv/commands/test/mock_galaxy.py
+++ b/tpv/commands/test/mock_galaxy.py
@@ -43,6 +43,9 @@ class Dataset:
         self.file_name = file_name
         self.file_size = file_size
 
+    def get_size(self, calculate_size=False):
+        return self.file_size
+
 
 # Tool mock and helpers=========================================
 class Tool:

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -13,7 +13,9 @@ GIGABYTES = 1024.0**3
 
 
 def get_dataset_size(dataset):
-    return float(dataset.file_size)
+    # calculate_size would mark file_size column as dirty
+    # and may have unintended consequences
+    return float(dataset.get_size(calculate_size=False))
 
 
 def sum_total(prev, current):


### PR DESCRIPTION
Fixes:

```
Oct 13 14:29:40 galaxy-vgp galaxyctl[2536822]:   File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/tpv/core/helpers.py", line 16, in get_dataset_size
Oct 13 14:29:40 galaxy-vgp galaxyctl[2536822]:     return float(dataset.file_size)
Oct 13 14:29:40 galaxy-vgp galaxyctl[2536822]: TypeError: float() argument must be a string or a number, not 'NoneType'
```

There's an underlying bug as well where the job state is final but the file size is unset, but I would always consider it better to use one abstraction level above the database column.