### PR TITLE
Add a helper to get the object store ids and the datasets size for every dataset in a job

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,20 @@
+"""Unit tests module for the helper functions"""
+import unittest
+from tpv.commands.test import mock_galaxy
+from tpv.core.helpers import get_dataset_attributes
+
+
+class TestHelpers(unittest.TestCase):
+    """Tests for helper functions"""
+    def test_get_dataset_attributes(self):
+        """Test that the function returns a dictionary with the correct attributes"""
+        job = mock_galaxy.Job()
+        job.add_input_dataset(
+            mock_galaxy.DatasetAssociation(
+                "test",
+                mock_galaxy.Dataset("test.txt", file_size=7*1024**3, object_store_id="files1")
+                )
+            )
+        dataset_attributes = get_dataset_attributes(job.input_datasets)
+        expected_result = {0: {'object_store_id': 'files1', 'size': 7*1024**3}}
+        self.assertEqual(dataset_attributes, expected_result)

--- a/tpv/commands/test/mock_galaxy.py
+++ b/tpv/commands/test/mock_galaxy.py
@@ -37,11 +37,12 @@ class DatasetAssociation:
 class Dataset:
     counter = 0
 
-    def __init__(self, file_name, file_size):
+    def __init__(self, file_name, file_size, object_store_id=None):
         self.id = self.counter
         self.counter += 1
         self.file_name = file_name
         self.file_size = file_size
+        self.object_store_id = object_store_id
 
     def get_size(self, calculate_size=False):
         return self.file_size

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -114,3 +114,13 @@ def tool_version_gte(tool, version):
 
 def tool_version_gt(tool, version):
     return parse_version(tool.version) > parse_version(version)
+
+
+def object_store_ids_and_dataset_size(job):
+    # Return a dictionary of dataset ids and their object store ids
+    # and file sizes in bytes for all input datasets in a job
+    object_store_ids = {}
+    for i in job.get_input_datasets():
+        object_store_ids[i.dataset.dataset.id] = (i.dataset.dataset.object_store_id, float(i.dataset.dataset.get_size(calculate_size=False)))
+
+    return object_store_ids

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -119,4 +119,9 @@ def tool_version_gt(tool, version):
 def get_dataset_attributes(datasets):
     # Return a dictionary of dataset ids and their object store ids
     # and file sizes in bytes for all input datasets in a job
-    return {i.dataset.dataset.id: {'object_store_id': i.dataset.dataset.object_store_id, 'size': get_dataset_size(i.dataset.dataset)} for i in datasets or {}}
+    return {
+        i.dataset.dataset.id: {
+            'object_store_id': i.dataset.dataset.object_store_id,
+            'size': get_dataset_size(i.dataset.dataset)}
+        for i in datasets or {}
+    }

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -119,8 +119,4 @@ def tool_version_gt(tool, version):
 def object_store_ids_and_dataset_size(job):
     # Return a dictionary of dataset ids and their object store ids
     # and file sizes in bytes for all input datasets in a job
-    object_store_ids = {}
-    for i in job.get_input_datasets():
-        object_store_ids[i.dataset.dataset.id] = (i.dataset.dataset.object_store_id, float(i.dataset.dataset.get_size(calculate_size=False)))
-
-    return object_store_ids
+    return {i.dataset.dataset.id: {'object_store_id': i.dataset.dataset.object_store_id, 'size': get_dataset_size(i.dataset.dataset)} for i in datasets or {}}

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -116,7 +116,7 @@ def tool_version_gt(tool, version):
     return parse_version(tool.version) > parse_version(version)
 
 
-def object_store_ids_and_dataset_size(job):
+def get_dataset_attributes(datasets):
     # Return a dictionary of dataset ids and their object store ids
     # and file sizes in bytes for all input datasets in a job
     return {i.dataset.dataset.id: {'object_store_id': i.dataset.dataset.object_store_id, 'size': get_dataset_size(i.dataset.dataset)} for i in datasets or {}}


### PR DESCRIPTION
This will be used in the ESG WP4 TPV meta-scheduling API for decision-making. If you think this is not useful for a larger audience, please close this PR. 