### PR TITLE
Alter TagSetManager score function to look at preference only

### DIFF
--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -149,10 +149,13 @@ class TagSetManager(object):
         :param other:
         :return:
         """
-        return (sum(int(tag.tag_type) * int(o.tag_type) for tag in self.tags for o in other.tags
-                    if tag.name == o.name and tag.value == o.value)
-                # penalize tags that don't exist in the other
-                - sum(int(tag.tag_type) for tag in self.tags if not other.contains_tag(tag)))
+        def a_prefers_b(a_tags, b_tags):
+            return any(
+                tag for tag in a_tags.filter(tag_type = TagType.PREFER)
+                if list(b_tags.filter(tag_type = [TagType.ACCEPT, TagType.PREFER, TagType.REQUIRE], tag_value = tag.value))
+            )
+        score = 1 if a_prefers_b(self.tags, other.tags) or a_prefers_b(other.tags, self.tags) else 0
+        return score
 
     def __eq__(self, other):
         if not isinstance(other, TagSetManager):


### PR DESCRIPTION
The score function counts all tags even if no PREFER tag is present and there is no reason to rank one destination higher than another.

I'd like to replace the score function with one that distinguishes only between pairs entities that prefer one another's tags and pairs that have no expressed preference for each other's tags.

@nuwang, I could keep this PR as is or add is_preferred(self, other) as a separate function returning a boolean.

I need to add a test to this.