### PR TITLE
Enhancement for dryrun: add --roles and --history-tags arguments

### DIFF
--- a/tests/fixtures/mapping-rules.yml
+++ b/tests/fixtures/mapping-rules.yml
@@ -62,8 +62,7 @@ users:
     rules:
       - id: magrathea_history_tag_rule
         if: |
-            map_to_magrathea = 'magrathea' in [hta.user_tname for hta in job.history.tags]
-            map_to_magrathea
+            'magrathea' in [hta.user_tname for hta in job.history.tags]
         scheduling:
           require:
             - commercial-council-of-magrathea

--- a/tests/fixtures/mapping-rules.yml
+++ b/tests/fixtures/mapping-rules.yml
@@ -39,6 +39,14 @@ tools:
         env:
           bwameth_is_great: yes
 users:
+  default:
+    rules:
+      - id: training_destination_rule
+        if: |
+          any([r for r in user.all_roles() if (not r.deleted and r.name.startswith('training'))])
+        scheduling:
+          require:
+            - training
   fairycake@vortex.org:
     env:
       TEST_JOB_SLOTS_USER: "{cores}"
@@ -50,6 +58,15 @@ users:
   krikkitrobot@planetkrikkit.org:
     env:
       TEST_JOB_SLOTS_USER: "{cores}"
+  slartibartfast@glacier.org:
+    rules:
+      - id: magrathea_history_tag_rule
+        if: |
+            map_to_magrathea = 'magrathea' in [hta.user_tname for hta in job.history.tags]
+            map_to_magrathea
+        scheduling:
+          require:
+            - commercial-council-of-magrathea
   arthur@vortex.org:
     scheduling:
       require:
@@ -87,3 +104,17 @@ destinations:
     scheduling:
       prefer:
         - pulsar
+  magrathea:
+    runner: local
+    max_accepted_cores: 4
+    max_accepted_mem: 16
+    scheduling:
+      require:
+        - commercial-council-of-magrathea
+  training:
+    runner: local
+    max_accepted_cores: 4
+    max_accepted_mem: 16
+    scheduling:
+      require:
+        - training

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -328,53 +328,25 @@ class TPVShellTestCase(unittest.TestCase):
                         f"Expected 'bwameth_is_great' in destination\n{output}")
 
     def test_dry_run_with_a_role(self):
-        job_config = os.path.join(
-            os.path.dirname(__file__), "fixtures/job_conf_dry_run.yml"
-        )
-        tpv_config = os.path.join(
-            os.path.dirname(__file__), "fixtures/mapping-rules.yml"
-        )
+        job_config = os.path.join(os.path.dirname(__file__), 'fixtures/job_conf_dry_run.yml')
+        tpv_config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-rules.yml')
         output = self.call_shell_command(
-            "tpv",
-            "dry-run",
-            "--job-conf",
-            job_config,
-            "--user",
-            "slartibartfast@glacier.org",
-            "--tool",
-            "toolshed.g2.bx.psu.edu/repos/iuc/towel/towel_coverage/42",
-            "--roles",
-            "training",
-            "--input-size",
-            "100",
-            tpv_config,
+            "tpv", "dry-run", "--job-conf", job_config, "--user", "slartibartfast@glacier.org",
+            "--tool", "toolshed.g2.bx.psu.edu/repos/iuc/towel/towel_coverage/42",
+            "--roles", "training", "--input-size", "100", tpv_config,
         )
         self.assertTrue(
             "id: training" in output,
             f"Expected 'id: training' destination\n{output}",
         )
 
-    def test_dry_run_when_history_got_a_tag(self):
-        job_config = os.path.join(
-            os.path.dirname(__file__), "fixtures/job_conf_dry_run.yml"
-        )
-        tpv_config = os.path.join(
-            os.path.dirname(__file__), "fixtures/mapping-rules.yml"
-        )
+    def test_dry_run_with_history_tag(self):
+        job_config = os.path.join(os.path.dirname(__file__), 'fixtures/job_conf_dry_run.yml')
+        tpv_config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-rules.yml')
         output = self.call_shell_command(
-            "tpv",
-            "dry-run",
-            "--job-conf",
-            job_config,
-            "--user",
-            "slartibartfast@glacier.org",
-            "--history-tags",
-            "magrathea",
-            "--input-size",
-            "100",
-            "--tool",
-            "toolshed.g2.bx.psu.edu/repos/iuc/towel/towel_qc/42",
-            tpv_config,
+            "tpv", "dry-run", "--job-conf", job_config, "--user", "slartibartfast@glacier.org",
+            "--history-tags", "magrathea", "--input-size", "100",
+            "--tool", "toolshed.g2.bx.psu.edu/repos/iuc/towel/towel_qc/42", tpv_config,
         )
         self.assertTrue(
             "id: magrathea" in output,

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -316,7 +316,7 @@ class TPVShellTestCase(unittest.TestCase):
             tpv_config)
         self.assertTrue("name: TEST_JOB_SLOTS_USER" in output,
                         f"Expected 'name: TEST_JOB_SLOTS_USER' in destination\n{output}")
-        
+
     def test_dry_run_tool_with_version(self):
         job_config = os.path.join(os.path.dirname(__file__), 'fixtures/job_conf_dry_run.yml')
         tpv_config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-rules.yml')
@@ -327,3 +327,56 @@ class TPVShellTestCase(unittest.TestCase):
         self.assertTrue("bwameth_is_great" in output,
                         f"Expected 'bwameth_is_great' in destination\n{output}")
 
+    def test_dry_run_with_a_role(self):
+        job_config = os.path.join(
+            os.path.dirname(__file__), "fixtures/job_conf_dry_run.yml"
+        )
+        tpv_config = os.path.join(
+            os.path.dirname(__file__), "fixtures/mapping-rules.yml"
+        )
+        output = self.call_shell_command(
+            "tpv",
+            "dry-run",
+            "--job-conf",
+            job_config,
+            "--user",
+            "slartibartfast@glacier.org",
+            "--tool",
+            "toolshed.g2.bx.psu.edu/repos/iuc/towel/towel_coverage/42",
+            "--roles",
+            "training",
+            "--input-size",
+            "100",
+            tpv_config,
+        )
+        self.assertTrue(
+            "id: training" in output,
+            f"Expected 'id: training' destination\n{output}",
+        )
+
+    def test_dry_run_when_history_got_a_tag(self):
+        job_config = os.path.join(
+            os.path.dirname(__file__), "fixtures/job_conf_dry_run.yml"
+        )
+        tpv_config = os.path.join(
+            os.path.dirname(__file__), "fixtures/mapping-rules.yml"
+        )
+        output = self.call_shell_command(
+            "tpv",
+            "dry-run",
+            "--job-conf",
+            job_config,
+            "--user",
+            "slartibartfast@glacier.org",
+            "--history-tags",
+            "magrathea",
+            "--input-size",
+            "100",
+            "--tool",
+            "toolshed.g2.bx.psu.edu/repos/iuc/towel/towel_qc/42",
+            tpv_config,
+        )
+        self.assertTrue(
+            "id: magrathea" in output,
+            f"Expected 'id: magrathea' destination\n{output}",
+        )

--- a/tpv/commands/dryrunner.py
+++ b/tpv/commands/dryrunner.py
@@ -21,12 +21,17 @@ class TPVDryRunner():
                                                tpv_config_files=self.tpv_config_files)
 
     @staticmethod
-    def from_params(job_conf, user=None, tool=None, tpv_confs=None, input_size=None):
+    def from_params(job_conf, user=None, tool=None, roles=None, history_tags=None, tpv_confs=None, input_size=None):
         if user is not None:
             email = user
             user = mock_galaxy.User('gargravarr', email)
         else:
             user = None
+
+        if roles:
+            if not user:
+                user = mock_galaxy.User("gargravarr", "gargravarr@vortex.org")
+            user.roles = [mock_galaxy.Role(role_name) for role_name in roles]
 
         if tool:
             tool = mock_galaxy.Tool(
@@ -42,5 +47,7 @@ class TPVDryRunner():
                 "test",
                 mock_galaxy.Dataset("test.txt", file_size=input_size*1024**3))
             job.add_input_dataset(dataset)
-
+        job.history = mock_galaxy.History()
+        if history_tags:
+            job.history.tags = [mock_galaxy.HistoryTag(tag_name) for tag_name in history_tags]
         return TPVDryRunner(job_conf=job_conf, tpv_confs=tpv_confs, user=user, tool=tool, job=job)

--- a/tpv/commands/shell.py
+++ b/tpv/commands/shell.py
@@ -56,7 +56,7 @@ def tpv_format_config_file(args):
 
 def tpv_dry_run_config_files(args):
     dry_runner = TPVDryRunner.from_params(user=args.user, tool=args.tool, job_conf=args.job_conf, tpv_confs=args.config,
-                                          input_size=args.input_size)
+                                          roles=args.roles, history_tags=args.history_tags, input_size=args.input_size)
     destination = dry_runner.run()
     yaml = YAML(typ='unsafe', pure=True)
     yaml.dump(destination, sys.stdout)
@@ -112,6 +112,15 @@ def create_parser():
     dry_run_parser.add_argument(
         '--user', type=str,
         help="Test mapping for Galaxy user with username or email")
+    dry_run_parser.add_argument(
+        '--roles', type=str, nargs='+',
+        help="Add one or more Galaxy roles for user")
+    dry_run_parser.add_argument(
+        "--history-tags",
+        type=str,
+        nargs="+",
+        help="Add one or more history tag names to user's history",
+    )
     dry_run_parser.add_argument(
         'config',
         nargs='*',

--- a/tpv/commands/test/mock_galaxy.py
+++ b/tpv/commands/test/mock_galaxy.py
@@ -14,6 +14,7 @@ class Job:
         self.input_library_datasets = []
         self.param_values = dict()
         self.parameters = []
+        self.history = None
 
     def add_input_dataset(self, dataset_association):
         self.input_datasets.append(JobToInputDatasetAssociation(dataset_association.name, dataset_association))
@@ -101,3 +102,14 @@ class Role:
     def __init__(self, name):
         self.name = name
         self.deleted = False
+
+
+class History:
+    def __init__(self, name='Unnamed TPV dry run history', tags=[]):
+        self.name = name
+        self.tags = [HistoryTag(tag_name) for tag_name in tags]
+
+
+class HistoryTag:
+    def __init__(self, user_tname):
+        self.user_tname = user_tname


### PR DESCRIPTION
To properly test our configuration I have added options for roles and history-tags to dryrun.