### PR TITLE
Add posibility to load multiple configs from xml job config

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,5 @@
 wheel
+parametrized
 galaxy-util
 galaxy-schema
 galaxy-objectstore

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 wheel
-parametrized
+pytest-parametrized
 galaxy-util
 galaxy-schema
 galaxy-objectstore

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 wheel
-pytest-parametrized
+parameterized
 galaxy-util
 galaxy-schema
 galaxy-objectstore

--- a/tests/fixtures/job_conf.xml
+++ b/tests/fixtures/job_conf.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<job_conf>
+  <plugins workers="4">
+    <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
+    <plugin id="drmaa" type="runner" load="galaxy.jobs.runners.drmaa:DRMAAJobRunner"/>
+    <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner"/>
+  </plugins>
+  <handlers>
+    <handlers assign_with="db-skip-locked"/>
+  </handlers>
+  <destinations default="tpv_dispatcher">
+    <destination id="tpv_dispatcher" runner="dynamic">
+      <param id="type">python</param>
+      <param id="function">map_tool_to_destination</param>
+      <param id="rules_module">tpv.rules</param>
+      <param id="tpv_config_files">https://github.com/galaxyproject/total-perspective-vortex/raw/main/tpv/tests/fixtures/mapping-rules.yml,config/tpv_rules_local.yml</param>
+
+      <param id="function">foo</param>
+  </destination>
+  </destinations>
+</job_conf>

--- a/tests/test_mapper_sample.py
+++ b/tests/test_mapper_sample.py
@@ -1,5 +1,9 @@
 import os
+import pytest
 import unittest
+
+from parameterized import parameterized
+
 from tpv.rules import gateway
 from tpv.commands.test import mock_galaxy
 
@@ -7,16 +11,20 @@ from tpv.commands.test import mock_galaxy
 class TestMapperSample(unittest.TestCase):
 
     @staticmethod
-    def _map_to_destination(tool):
-        galaxy_app = mock_galaxy.App(job_conf=os.path.join(os.path.dirname(__file__), 'fixtures/job_conf.yml'))
+    def _map_to_destination(tool, job_conf):
+        galaxy_app = mock_galaxy.App(job_conf=os.path.join(os.path.dirname(__file__), job_conf), create_model=True)
         job = mock_galaxy.Job()
         user = mock_galaxy.User('gargravarr', 'fairycake@vortex.org')
         tpv_config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-sample.yml')
         gateway.ACTIVE_DESTINATION_MAPPER = None
         return gateway.map_tool_to_destination(galaxy_app, job, tool, user, tpv_config_files=[tpv_config])
 
-    def test_map_sample_tool(self):
+    @parameterized.expand([
+        "fixtures/job_conf.yml",
+        "fixtures/job_conf.xml",
+    ])
+    def test_map_sample_tool(self, job_conf):
         tool = mock_galaxy.Tool('sometool')
-        destination = self._map_to_destination(tool)
+        destination = self._map_to_destination(tool, job_conf)
         self.assertEqual(destination.id, "local")
         self.assertEqual(destination.params['local_slots'], '2')

--- a/tpv/rules/gateway.py
+++ b/tpv/rules/gateway.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import List, Union
 
 from galaxy.util.watcher import get_watcher
 from tpv.core.loader import TPVConfigLoader
@@ -12,7 +13,9 @@ ACTIVE_DESTINATION_MAPPER = None
 CONFIG_WATCHERS = {}
 
 
-def load_destination_mapper(tpv_config_files, reload=False):
+def load_destination_mapper(tpv_config_files: Union[List[str], str], reload=False):
+    if isinstance(tpv_config_files, str):
+        tpv_config_files = tpv_config_files.split(",")
     log.info(f"{'re' if reload else ''}loading tpv rules from: {tpv_config_files}")
     loader = None
     for tpv_config_file in tpv_config_files:
@@ -24,7 +27,7 @@ def load_destination_mapper(tpv_config_files, reload=False):
     return EntityToDestinationMapper(loader)
 
 
-def setup_destination_mapper(app, tpv_config_files):
+def setup_destination_mapper(app, tpv_config_files: Union[List[str], str]):
     mapper = load_destination_mapper(tpv_config_files)
 
     def reload_destination_mapper(path=None):
@@ -43,7 +46,7 @@ def setup_destination_mapper(app, tpv_config_files):
     return mapper
 
 
-def map_tool_to_destination(app, job, tool, user, tpv_config_files, job_wrapper=None, resource_params=None,
+def map_tool_to_destination(app, job, tool, user, tpv_config_files: Union[List[str], str], job_wrapper=None, resource_params=None,
                             workflow_invocation_uuid=None):
     global ACTIVE_DESTINATION_MAPPER
     if not ACTIVE_DESTINATION_MAPPER:

--- a/tpv/rules/gateway.py
+++ b/tpv/rules/gateway.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import List, Union
 
+from galaxy.util import listify
 from galaxy.util.watcher import get_watcher
 from tpv.core.loader import TPVConfigLoader
 from tpv.core.mapper import EntityToDestinationMapper
@@ -14,8 +15,7 @@ CONFIG_WATCHERS = {}
 
 
 def load_destination_mapper(tpv_config_files: Union[List[str], str], reload=False):
-    if isinstance(tpv_config_files, str):
-        tpv_config_files = tpv_config_files.split(",")
+    tpv_config_files = listify(tpv_config_files)
     log.info(f"{'re' if reload else ''}loading tpv rules from: {tpv_config_files}")
     loader = None
     for tpv_config_file in tpv_config_files:

--- a/tpv/rules/gateway.py
+++ b/tpv/rules/gateway.py
@@ -46,8 +46,16 @@ def setup_destination_mapper(app, tpv_config_files: Union[List[str], str]):
     return mapper
 
 
-def map_tool_to_destination(app, job, tool, user, tpv_config_files: Union[List[str], str], job_wrapper=None, resource_params=None,
-                            workflow_invocation_uuid=None):
+def map_tool_to_destination(
+    app,
+    job,
+    tool,
+    user,
+    tpv_config_files: Union[List[str], str],
+    job_wrapper=None,
+    resource_params=None,
+    workflow_invocation_uuid=None,
+):
     global ACTIVE_DESTINATION_MAPPER
     if not ACTIVE_DESTINATION_MAPPER:
         ACTIVE_DESTINATION_MAPPER = setup_destination_mapper(app, tpv_config_files)


### PR DESCRIPTION
I'm still using xml based job config (and will need to stick to it for a while, since I use macros a lot) and could not thing of a way to configure multiple TPV config files .. maybe like so? 