### PR TITLE
Wrap tool version comparision in a function that checks for None

### DIFF
--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -5,9 +5,10 @@ except ImportError:
     # If Galaxy is < 23.1 you need to have `packaging` in <= 21.3
     from packaging.version import parse as parse_version
 
+import operator
 import random
 from functools import reduce
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from galaxy import model
 from galaxy.app import UniverseApplication
@@ -129,24 +130,30 @@ def tag_values_match(
     )
 
 
-def tool_version_eq(tool: GalaxyTool, version: str) -> bool:
-    return parse_version(tool.version) == parse_version(version)
+def __compare_tool_versions(versionA: Optional[str], versionB: Optional[str], comparator: Callable[[Any, Any], bool]) -> Optional[bool]:
+    if versionA is None or versionB is None:
+        return None
+    return comparator(parse_version(versionA), parse_version(versionB))
 
 
-def tool_version_lte(tool: GalaxyTool, version: str) -> bool:
-    return parse_version(tool.version) <= parse_version(version)
+def tool_version_eq(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
+    return __compare_tool_versions(tool.version, version, operator.eq)
 
 
-def tool_version_lt(tool: GalaxyTool, version: str) -> bool:
-    return parse_version(tool.version) < parse_version(version)
+def tool_version_lte(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
+    return __compare_tool_versions(tool.version, version, operator.lte)
 
 
-def tool_version_gte(tool: GalaxyTool, version: str) -> bool:
-    return parse_version(tool.version) >= parse_version(version)
+def tool_version_lt(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
+    return __compare_tool_versions(tool.version, version, operator.lt)
 
 
-def tool_version_gt(tool: GalaxyTool, version: str) -> bool:
-    return parse_version(tool.version) > parse_version(version)
+def tool_version_gte(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
+    return __compare_tool_versions(tool.version, version, operator.gte)
+
+
+def tool_version_gt(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
+    return __compare_tool_versions(tool.version, version, operator.gt)
 
 
 def get_dataset_attributes(

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -130,7 +130,9 @@ def tag_values_match(
     )
 
 
-def __compare_tool_versions(versionA: Optional[str], versionB: Optional[str], comparator: Callable[[Any, Any], bool]) -> Optional[bool]:
+def __compare_tool_versions(
+    versionA: Optional[str], versionB: Optional[str], comparator: Callable[[Any, Any], bool]
+) -> Optional[bool]:
     if versionA is None or versionB is None:
         return None
     return comparator(parse_version(versionA), parse_version(versionB))

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -131,7 +131,9 @@ def tag_values_match(
 
 
 def __compare_tool_versions(
-    versionA: Optional[str], versionB: Optional[str], comparator: Callable[[Any, Any], bool]
+    versionA: Optional[str],
+    versionB: Optional[str],
+    comparator: Callable[[Any, Any], bool],
 ) -> Optional[bool]:
     if versionA is None or versionB is None:
         return None
@@ -143,7 +145,7 @@ def tool_version_eq(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
 
 
 def tool_version_lte(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
-    return __compare_tool_versions(tool.version, version, operator.lte)
+    return __compare_tool_versions(tool.version, version, operator.le)
 
 
 def tool_version_lt(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
@@ -151,7 +153,7 @@ def tool_version_lt(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
 
 
 def tool_version_gte(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:
-    return __compare_tool_versions(tool.version, version, operator.gte)
+    return __compare_tool_versions(tool.version, version, operator.ge)
 
 
 def tool_version_gt(tool: GalaxyTool, version: Optional[str]) -> Optional[bool]:


### PR DESCRIPTION
For issue https://github.com/galaxyproject/total-perspective-vortex/issues/115

calling parse_version(X) where X is None will cause an exception to be thrown. This can be prevented by catching the Nones beforehand.

I haven’t tested this locally.