### PR TITLE
remove pipe synthax only available from py3.10

### DIFF
--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -15,6 +15,9 @@ from typing import (
     List,
     Optional,
     Set,
+    Type,
+    TypeVar,
+    Union,
     cast,
 )
 
@@ -48,7 +51,7 @@ class TryNextDestinationOrWait(Exception):
 class TPVFieldMetadata:
     # complex properties are always evaluated as f-strings
     complex_property: bool = False
-    return_type: type | None = None
+    return_type: Union[type, None] = None
     eval_as_f_string: bool = False
 
 
@@ -140,7 +143,7 @@ class SchedulingTags(BaseModel):
 
     def filter(
         self,
-        tag_type: Optional[TagType | list[TagType]] = None,
+        tag_type: Optional[Union[TagType, list[TagType]]] = None,
         tag_value: Optional[str] = None,
     ) -> Iterable[Tag]:
         filtered = self.tags
@@ -245,15 +248,15 @@ class Entity(BaseModel):
     id: str = ""
     abstract: Optional[bool] = False
     inherits: Optional[str] = None
-    cores: Annotated[Optional[int | float | str], TPVFieldMetadata()] = None
-    mem: Annotated[Optional[int | float | str], TPVFieldMetadata()] = None
-    gpus: Annotated[Optional[int | str], TPVFieldMetadata()] = None
-    min_cores: Annotated[Optional[int | float | str], TPVFieldMetadata()] = None
-    min_mem: Annotated[Optional[int | float | str], TPVFieldMetadata()] = None
-    min_gpus: Annotated[Optional[int | str], TPVFieldMetadata()] = None
-    max_cores: Annotated[Optional[int | float | str], TPVFieldMetadata()] = None
-    max_mem: Annotated[Optional[int | float | str], TPVFieldMetadata()] = None
-    max_gpus: Annotated[Optional[int | str], TPVFieldMetadata()] = None
+    cores: Annotated[Optional[Union[int, float, str]], TPVFieldMetadata()] = None
+    mem: Annotated[Optional[Union[int, float, str]], TPVFieldMetadata()] = None
+    gpus: Annotated[Optional[Union[int, str]], TPVFieldMetadata()] = None
+    min_cores: Annotated[Optional[Union[int, float, str]], TPVFieldMetadata()] = None
+    min_mem: Annotated[Optional[Union[int, float, str]], TPVFieldMetadata()] = None
+    min_gpus: Annotated[Optional[Union[int, str]], TPVFieldMetadata()] = None
+    max_cores: Annotated[Optional[Union[int, float, str]], TPVFieldMetadata()] = None
+    max_mem: Annotated[Optional[Union[int, float, str]], TPVFieldMetadata()] = None
+    max_gpus: Annotated[Optional[Union[int, str]], TPVFieldMetadata()] = None
     env: Annotated[Optional[List[Dict[str, str]]], TPVFieldMetadata(complex_property=True)] = None
     params: Annotated[Optional[Dict[str, Any]], TPVFieldMetadata(complex_property=True)] = None
     resubmit: Annotated[Dict[str, str], TPVFieldMetadata(complex_property=True)] = Field(default_factory=lambda: dict())
@@ -287,7 +290,7 @@ class Entity(BaseModel):
                         else:
                             evaluator.compile_code_block(value)
 
-    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
+    def __deepcopy__(self, memo: Union[dict[int, Any], None] = None) -> Self:
         # satisfy mypy by ensuring memo is never None
         if memo is None:
             memo = {}  # pragma: no cover
@@ -490,7 +493,7 @@ class Entity(BaseModel):
 class Rule(Entity):
     rule_counter: ClassVar[int] = 0
     id: str = Field(default_factory=lambda: Rule.set_default_id())
-    if_condition: Annotated[str | bool, TPVFieldMetadata()] = Field(alias="if")
+    if_condition: Annotated[Union[str, bool], TPVFieldMetadata()] = Field(alias="if")
     execute: Annotated[Optional[str], TPVFieldMetadata(return_type=type(None))] = None
     fail: Annotated[Optional[str], TPVFieldMetadata(eval_as_f_string=True)] = None
 
@@ -588,11 +591,11 @@ class User(EntityWithRules):
 class Destination(EntityWithRules):
     merge_order: ClassVar[int] = 5
     runner: Optional[str] = None
-    max_accepted_cores: Optional[int | float] = None
-    max_accepted_mem: Optional[int | float] = None
+    max_accepted_cores: Optional[Union[int, float]] = None
+    max_accepted_mem: Optional[Union[int, float]] = None
     max_accepted_gpus: Optional[int] = None
-    min_accepted_cores: Optional[int | float] = None
-    min_accepted_mem: Optional[int | float] = None
+    min_accepted_cores: Optional[Union[int, float]] = None
+    min_accepted_mem: Optional[Union[int, float]] = None
     min_accepted_gpus: Optional[int] = None
     dest_name: Optional[str] = Field(alias="destination_name_override", default=None)
     # tpv_tags track what tags the entity being scheduled requested, while tpv_dest_tags track what the destination

--- a/tpv/core/evaluator.py
+++ b/tpv/core/evaluator.py
@@ -1,6 +1,6 @@
 import abc
 from types import CodeType
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Union, Tuple
 
 
 class TPVCodeEvaluator(abc.ABC):
@@ -8,7 +8,7 @@ class TPVCodeEvaluator(abc.ABC):
     @abc.abstractmethod
     def compile_code_block(
         self, code: str, as_f_string: bool = False, exec_only: bool = False
-    ) -> tuple[CodeType, CodeType | None]:
+    ) -> tuple[CodeType, Union[CodeType, None]]:
         pass  # pragma: no cover
 
     @abc.abstractmethod


### PR DESCRIPTION
OS Alma9
Python 3.9 

It is mentioned in the documentation that TPV >=3.9, but I got the error message of type str | bool, only working >= Python 3.10

I suggest the modification of 2 scripts, replacing pipe syntax by Union[str, bool] 
tpv/core/evaluator.py
tpv/core/entities.py

Cheers,