### PR TITLE
Reenable resubmit tests + some resubmit test fixes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,7 +117,7 @@ jobs:
           key: tox-cache-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml', '**/setup.py', '**/requirements.txt', '**/requirements_test.txt', '**/tox.ini') }}-py310
 
       - name: Run tox
-        run: uvx --with tox-uv tox -e py${{ matrix.python-version }}
+        run: uvx --with tox-uv tox -e py${{ matrix.python-version }} -- --runslow
         env:
           PYTHONUNBUFFERED: "True"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,15 @@ import pytest
 
 from tpv.rules import gateway
 
+# Galaxy's IntegrationTestCase now mixes in UsesCeleryTasks, whose autouse
+# fixtures require the celery pytest plugin and a celery_includes fixture.
+pytest_plugins = ("celery.contrib.pytest",)
+
+
+@pytest.fixture(scope="session")
+def celery_includes():
+    return ["galaxy.celery.tasks"]
+
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")

--- a/tests/fixtures/resubmit/exit_code_oom_no_resubmit.xml
+++ b/tests/fixtures/resubmit/exit_code_oom_no_resubmit.xml
@@ -5,7 +5,8 @@
     </stdio>
     <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
 mv hi.txt '$out_file1' &&
-echo "OOM_TOOL_MEMORY \$OOM_TOOL_MEMORY" &&
+echo >> '$out_file1' &&
+echo "OOM_TOOL_MEMORY \$OOM_TOOL_MEMORY" >> '$out_file1' &&
 if [[ -z \$OOM_TOOL_MEMORY ]]; then
     exit 1;
 fi &&

--- a/tests/fixtures/resubmit/exit_code_oom_with_resubmit.xml
+++ b/tests/fixtures/resubmit/exit_code_oom_with_resubmit.xml
@@ -5,7 +5,8 @@
     </stdio>
     <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
 mv hi.txt '$out_file1' &&
-echo "OOM_TOOL_MEMORY \$OOM_TOOL_MEMORY" &&
+echo >> '$out_file1' &&
+echo "OOM_TOOL_MEMORY \$OOM_TOOL_MEMORY" >> '$out_file1' &&
 if [[ -z \$OOM_TOOL_MEMORY ]]; then
     exit 1;
 fi &&

--- a/tests/test_mapper_params_specific.py
+++ b/tests/test_mapper_params_specific.py
@@ -61,12 +61,15 @@ class TestParamsSpecific(unittest.TestCase):
         user = mock_galaxy.User("trillian", "panic@vortex.org")
 
         destination = self._map_to_destination(tool, user)
+        # Galaxy's resubmit state handler reads the target destination from the
+        # "environment" key, so TPV's user-facing "destination" key must be
+        # translated when building the Galaxy JobDestination.
         self.assertEqual(
             destination.resubmit,
             [
                 {
                     "condition": "memory_limit_reached and attempt <= 3",
-                    "destination": "tpv_dispatcher",
+                    "environment": "tpv_dispatcher",
                     "delay": "attempt * 30",
                 }
             ],

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -6,7 +6,7 @@ from typing import Any, TypeVar, cast
 
 from cachetools import Cache, cached
 from galaxy.app import UniverseApplication
-from galaxy.jobs import JobDestination, JobWrapper
+from galaxy.jobs import JobDestination, JobWrapper, ResubmitConfigDict
 from galaxy.jobs.mapper import JobNotReadyException
 from galaxy.model import Job
 from galaxy.model import User as GalaxyUser
@@ -206,6 +206,17 @@ class EntityToDestinationMapper(object):
                 )
         return ranked
 
+    @staticmethod
+    def _to_galaxy_resubmit(resubmit_def: dict[str, Any]) -> ResubmitConfigDict:
+        # TPV's resubmit definitions mirror Galaxy's user-facing job_conf and
+        # use the "destination" key. Galaxy's resubmit state handler, however,
+        # reads the target from "environment" (job_conf parsing performs the
+        # same rename), so translate it when building the JobDestination.
+        resubmit = dict(resubmit_def)
+        if "destination" in resubmit:
+            resubmit["environment"] = resubmit.pop("destination")
+        return cast(ResubmitConfigDict, resubmit)
+
     def to_galaxy_destination(self, destination: Destination) -> JobDestination:
         return JobDestination(
             id=destination.dest_name,
@@ -213,7 +224,7 @@ class EntityToDestinationMapper(object):
             runner=destination.runner,
             params=destination.params or {},
             env=destination.env or [],
-            resubmit=list(destination.resubmit.values()),  # type: ignore[arg-type]
+            resubmit=[self._to_galaxy_resubmit(r) for r in destination.resubmit.values()],
         )
 
     def _find_matching_entities(


### PR DESCRIPTION
TPV's resubmit integration tests (tests/test_mapper_resubmit.py) were failing against current Galaxy. This fixes three issues uncovered along the way.

Depends on: https://github.com/galaxyproject/galaxy/pull/22670

Running the resubmit tests locally
These tests are @pytest.mark.slow and spin up a full Galaxy server. To run them against a Galaxy checkout that has the fix:

#### GV = path to a Galaxy checkout on the resubmit-chaining branch
```
PYTHONPATH=$GV/lib $GV/.venv/bin/pytest tests/test_mapper_resubmit.py --runslow -v
```

Use Galaxy's own venv plus `PYTHONPATH=$GV/lib` so the branch source under lib/ is what runs (a pip-installed galaxy would shadow it). The venv may need parameterized and psycopg[binary].