### PR TITLE
Add per-user resource pools

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,6 +92,18 @@ jobs:
       matrix:
         python-version: ['3.10']
 
+    services:
+      # Real Valkey for the resource pool integration tests (tests/test_mapper_resource_pool_integration.py).
+      valkey:
+        image: valkey/valkey:8
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -120,6 +132,8 @@ jobs:
         run: uvx --with tox-uv tox -e py${{ matrix.python-version }} -- --runslow
         env:
           PYTHONUNBUFFERED: "True"
+          # The pool integration tests skip without a Valkey locally; in CI that must be a failure.
+          TPV_TEST_REQUIRE_VALKEY: "1"
 
       - name: Coveralls
         uses: AndreMiras/coveralls-python-action@develop

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,13 @@
 Unreleased
 --------------------------------------------------------------------
-* Add per-user resource pools. ``helpers.enforce_resource_pool(context, name=...)`` caps the
-  aggregate cores/memory/GPUs a user may consume concurrently, with an optional oversize
-  allowance for big non-UDT tools. Allocations are tracked in a pluggable, Valkey-backed
-  store (no data is written to Galaxy's database) and pools are declared under
-  ``global.resource_pools``. See the "Per-user resource pools" docs section.
+* Add per-user resource pools. A ``pools:`` collection makes a resource pool a first-class TPV
+  entity that caps the aggregate ``max_concurrent_cores``/``mem``/``gpus`` a user may consume
+  concurrently, with an optional oversize allowance for big non-UDT tools. Tag matching selects
+  which pool(s) govern a job, and per-user/role budgets are resolved by the existing
+  ``inherit``/``combine`` precedence; enforcement is an automatic step of the mapping pipeline.
+  Allocations are tracked in a pluggable, Valkey-backed store (no data is written to Galaxy's
+  database), wired under ``global.resource_pool_store``. Enforcement is fail-closed, with an
+  optional per-pool ``fail_open``. See the "Per-user resource pools" docs section.
 
 3.2.1 - Apr 13, 2026. (sha c5c317f8613ca66446af38eba4e865c20d62ac45)
 --------------------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+Unreleased
+--------------------------------------------------------------------
+* Add per-user resource pools. ``helpers.enforce_resource_pool(context, name=...)`` caps the
+  aggregate cores/memory/GPUs a user may consume concurrently, with an optional oversize
+  allowance for big non-UDT tools. Allocations are tracked in a pluggable, Valkey-backed
+  store (no data is written to Galaxy's database) and pools are declared under
+  ``global.resource_pools``. See the "Per-user resource pools" docs section.
+
 3.2.1 - Apr 13, 2026. (sha c5c317f8613ca66446af38eba4e865c20d62ac45)
 --------------------------------------------------------------------
 * Replace deprecated pydantic class Config with ConfigDict by @mvdbeek (PR #191)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ Unreleased
   ``inherit``/``combine`` precedence; enforcement is an automatic step of the mapping pipeline.
   Allocations are tracked in a pluggable, Valkey-backed store (no data is written to Galaxy's
   database), wired under ``global.resource_pool_store``. Enforcement is fail-closed, with an
-  optional per-pool ``fail_open``. See the "Per-user resource pools" docs section.
+  optional per-pool ``fail_open``. Pool allocations persist until job-state reconciliation
+  releases them, and matching pools admit a job atomically after destination evaluation.
+  See the "Per-user resource pools" docs section, including Galaxy ready-window limitations.
 
 3.2.1 - Apr 13, 2026. (sha c5c317f8613ca66446af38eba4e865c20d62ac45)
 --------------------------------------------------------------------

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -591,54 +591,54 @@ A *resource pool* caps the aggregate cores, memory and GPUs a single user may co
 their concurrently active jobs. This is important when exposing User Defined Tools (UDTs),
 where one user could otherwise submit many jobs and monopolise the cluster.
 
-Pools are declared once under ``global.resource_pools`` and enforced from a rule by calling
-``helpers.enforce_resource_pool(context, name=...)``. Because the rule can live on the
-``default`` tool (which every tool inherits), a single rule enforces a pool across *every*
-job:
+Pools are a **first-class TPV entity**, declared in a top-level ``pools:`` collection alongside
+``tools:``, ``users:``, ``roles:`` and ``destinations:``. A pool governs a job when the job's
+requested scheduling tags match the pool's tags — exactly the tag matching a destination uses.
+The only thing that lives under ``global`` is the *infrastructure* wiring for the allocation
+store (a backend URL and TTL); the budget *policy* lives on the pool entities. Enforcement is
+automatic: no rule to attach, no helper to call.
 
 .. code-block:: yaml
    :linenos:
 
    global:
-     default_inherits: default
-     resource_pools:
-       # Pluggable store. The default ValkeyAllocationStore keeps allocations in Valkey,
-       # NOT in Galaxy's database. Use InMemoryAllocationStore for a single process / tests.
-       store: tpv.core.resource_pool.ValkeyAllocationStore
-       store_options:
-         url: valkey://localhost:6379/0
-         ttl: 3600
-       pools:
-         default:
-           max_cores: 32
-           max_mem: 256          # GB, matching the TPV ``mem`` convention
-         gpu:
-           max_gpus: 2
+     # Infrastructure only. The default ValkeyAllocationStore keeps allocations in Valkey,
+     # NOT in Galaxy's database. Use InMemoryAllocationStore for a single process / tests.
+     resource_pool_store:
+       class: tpv.core.resource_pool.ValkeyAllocationStore
+       url: valkey://localhost:6379/0
+       ttl: 3600
 
-   tools:
+   pools:
+     # No require tags -> governs every job (that a reject tag does not exclude).
      default:
-       cores: 2
-       mem: cores * 3
-       rules:
-         - id: enforce_default_pool
-           if: entity.cores or entity.mem or entity.gpus
-           execute: |
-             helpers.enforce_resource_pool(context, name="default")
+       max_concurrent_cores: 32
+       max_concurrent_mem: 256      # GB, matching the TPV ``mem`` convention
+     # A second, independent pool that governs only jobs tagged ``gpu``.
+     gpu:
+       scheduling:
+         require:
+           - gpu
+       max_concurrent_gpus: 2
 
-When admitting a job would push the user over the pool budget, the job is **deferred**
-(re-queued and retried later) rather than failed. A second, independent pool is just another
-named pool and another rule — for example a GPU pool gated on ``if: entity.gpus``:
+The ``max_concurrent_*`` naming is deliberate: it keeps the per-user-aggregate budget distinct
+from a tool's per-job ``cores``/``mem``/``gpus`` request and from a destination's
+``max_accepted_*`` per-job capacity. When admitting a job would push the user over the pool
+budget, the job is **deferred** (re-queued and retried later) rather than failed.
+
+Per-user and per-role budgets fall out of the entity model — no bespoke provider. Because a
+pool sits *below* Tool/Role/User in merge order, a ``max_concurrent_*`` set on a Role or User is
+resolved by the ordinary ``inherit`` + ``combine`` precedence and overrides the pool default:
 
 .. code-block:: yaml
    :linenos:
 
-   tools:
-     default:
-       rules:
-         - id: enforce_gpu_pool
-           if: entity.gpus
-           execute: |
-             helpers.enforce_resource_pool(context, name="gpu")
+   roles:
+     power_users:
+       max_concurrent_cores: 128    # this role gets a bigger budget
+   users:
+     trillian@vortex.org:
+       max_concurrent_gpus: 4       # this user overrides the gpu pool budget
 
 Allowing oversize jobs
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -647,31 +647,41 @@ permit such *oversize* jobs up to a small concurrency limit instead of rejecting
 
 .. code-block:: yaml
    :linenos:
-   :emphasize-lines: 6,7,8,9
+   :emphasize-lines: 5,6,7,8
 
-   global:
-     resource_pools:
-       pools:
-         general:
-           max_cores: 32
-           oversize:
-             max_concurrent: 1     # at most one over-budget job at a time per user
-             hard_max_cores: 128   # but never more than this — always fail beyond it
-         udt:
-           max_cores: 16
-           # no `oversize` block (max_concurrent defaults to 0): over-budget UDT jobs fail
+   pools:
+     general:
+       max_concurrent_cores: 32
+       oversize:
+         max_concurrent: 1        # at most one over-budget job at a time per user
+         hard_max_cores: 128      # but never more than this — always fail beyond it
+     udt:
+       scheduling:
+         require:
+           - tool_type_user_defined
+       max_concurrent_cores: 16
+       # no `oversize` block (max_concurrent defaults to 0): over-budget UDT jobs fail
 
 A job whose request fits the budget is admitted normally. A job that exceeds the budget is
 *oversize*: it is admitted only while fewer than ``max_concurrent`` oversize jobs are running,
 deferred otherwise, and failed outright when ``max_concurrent`` is ``0`` or the request
-exceeds a ``hard_max_*`` ceiling. Route UDTs through a pool without an oversize allowance, and
-trusted tools through one that permits it, by attaching the appropriate rule (e.g. gate UDTs
-on the ``tool_type_user_defined`` tag).
+exceeds a ``hard_max_*`` ceiling. Route UDTs through a pool without an oversize allowance (gate
+it on the ``tool_type_user_defined`` tag) and trusted tools through one that permits it.
 
 .. note::
-   Enforcement is **fail-closed**: if the allocation store cannot be reached, pool-governed
-   jobs are deferred rather than admitted, so an outage never silently bypasses the limits.
-   Treat Valkey as a scheduling dependency. Budgets are resolved through a pluggable
-   ``BudgetProvider``; the default returns one flat budget per pool for every user, and a
-   custom provider can vary budgets by user, role or an external service without changing
-   rules.
+   **What a pool counts.** A pool counts the resources a job *asks for*, measured before a
+   destination gets to shrink them — so a destination that caps cores does not reduce what the
+   pool charges the user. The check runs once a suitable destination is known to exist (a job
+   with nowhere to run is never counted) but before the destination is finalised, so the count
+   does not depend on which destination is chosen.
+
+.. note::
+   Enforcement is **fail-closed**: if the allocation store cannot be reached, TPV cannot check
+   how much the user is already using, so it plays it safe and **defers** the job rather than
+   admitting one that might blow past the budget (fail-closed = "when unsure, say no"). This
+   means an outage never silently bypasses the limits — but it also means **Valkey is a
+   scheduling dependency**: because the ``default`` pool governs every job, a Valkey outage will
+   defer every governed job on the instance. If that trade-off is too strict for a given pool,
+   set ``fail_open: true`` on it to admit jobs during an outage instead ("when unsure, let it
+   through"). Leave it off (the default) for UDT/security pools, where letting a user exceed the
+   limit is worse than making them wait.

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -588,10 +588,11 @@ property.
 Per-user resource pools
 -----------------------
 A *resource pool* caps the aggregate cores, memory and GPUs a single user may consume across
-their concurrently active jobs — a general way to stop any one user from monopolising the
-cluster by submitting many jobs at once. It is particularly useful when exposing User Defined
-Tools (UDTs), where untrusted, user-authored tools make such a limit essential, but it applies
-just as well to ordinary tools.
+their concurrently active jobs. This bounds a user's total resource *consumption*, complementing
+Galaxy's existing concurrency limits, which bound the *number* of concurrent jobs — ten small
+jobs and ten large jobs hit the same job-count limit but tie up very different amounts of the
+cluster. Support for User Defined Tools (UDTs) was the motivating use case, but the feature
+applies to any tool.
 
 Pools are a **first-class TPV entity**, declared in a top-level ``pools:`` collection alongside
 ``tools:``, ``users:``, ``roles:`` and ``destinations:``. A pool governs a job when the job's

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -588,8 +588,10 @@ property.
 Per-user resource pools
 -----------------------
 A *resource pool* caps the aggregate cores, memory and GPUs a single user may consume across
-their concurrently active jobs. This is important when exposing User Defined Tools (UDTs),
-where one user could otherwise submit many jobs and monopolise the cluster.
+their concurrently active jobs — a general way to stop any one user from monopolising the
+cluster by submitting many jobs at once. It is particularly useful when exposing User Defined
+Tools (UDTs), where untrusted, user-authored tools make such a limit essential, but it applies
+just as well to ordinary tools.
 
 Pools are a **first-class TPV entity**, declared in a top-level ``pools:`` collection alongside
 ``tools:``, ``users:``, ``roles:`` and ``destinations:``. A pool governs a job when the job's

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -583,3 +583,95 @@ property.
      slurm:
        runner: slurm
        destination_name_override: "my-dest-with-{cores}-cores-{mem}-mem"
+
+
+Per-user resource pools
+-----------------------
+A *resource pool* caps the aggregate cores, memory and GPUs a single user may consume across
+their concurrently active jobs. This is important when exposing User Defined Tools (UDTs),
+where one user could otherwise submit many jobs and monopolise the cluster.
+
+Pools are declared once under ``global.resource_pools`` and enforced from a rule by calling
+``helpers.enforce_resource_pool(context, name=...)``. Because the rule can live on the
+``default`` tool (which every tool inherits), a single rule enforces a pool across *every*
+job:
+
+.. code-block:: yaml
+   :linenos:
+
+   global:
+     default_inherits: default
+     resource_pools:
+       # Pluggable store. The default ValkeyAllocationStore keeps allocations in Valkey,
+       # NOT in Galaxy's database. Use InMemoryAllocationStore for a single process / tests.
+       store: tpv.core.resource_pool.ValkeyAllocationStore
+       store_options:
+         url: valkey://localhost:6379/0
+         ttl: 3600
+       pools:
+         default:
+           max_cores: 32
+           max_mem: 256          # GB, matching the TPV ``mem`` convention
+         gpu:
+           max_gpus: 2
+
+   tools:
+     default:
+       cores: 2
+       mem: cores * 3
+       rules:
+         - id: enforce_default_pool
+           if: entity.cores or entity.mem or entity.gpus
+           execute: |
+             helpers.enforce_resource_pool(context, name="default")
+
+When admitting a job would push the user over the pool budget, the job is **deferred**
+(re-queued and retried later) rather than failed. A second, independent pool is just another
+named pool and another rule — for example a GPU pool gated on ``if: entity.gpus``:
+
+.. code-block:: yaml
+   :linenos:
+
+   tools:
+     default:
+       rules:
+         - id: enforce_gpu_pool
+           if: entity.gpus
+           execute: |
+             helpers.enforce_resource_pool(context, name="gpu")
+
+Allowing oversize jobs
+~~~~~~~~~~~~~~~~~~~~~~~~
+Some trusted (non-UDT) tools legitimately need more than the whole pool budget. A pool may
+permit such *oversize* jobs up to a small concurrency limit instead of rejecting them:
+
+.. code-block:: yaml
+   :linenos:
+   :emphasize-lines: 6,7,8,9
+
+   global:
+     resource_pools:
+       pools:
+         general:
+           max_cores: 32
+           oversize:
+             max_concurrent: 1     # at most one over-budget job at a time per user
+             hard_max_cores: 128   # but never more than this — always fail beyond it
+         udt:
+           max_cores: 16
+           # no `oversize` block (max_concurrent defaults to 0): over-budget UDT jobs fail
+
+A job whose request fits the budget is admitted normally. A job that exceeds the budget is
+*oversize*: it is admitted only while fewer than ``max_concurrent`` oversize jobs are running,
+deferred otherwise, and failed outright when ``max_concurrent`` is ``0`` or the request
+exceeds a ``hard_max_*`` ceiling. Route UDTs through a pool without an oversize allowance, and
+trusted tools through one that permits it, by attaching the appropriate rule (e.g. gate UDTs
+on the ``tool_type_user_defined`` tag).
+
+.. note::
+   Enforcement is **fail-closed**: if the allocation store cannot be reached, pool-governed
+   jobs are deferred rather than admitted, so an outage never silently bypasses the limits.
+   Treat Valkey as a scheduling dependency. Budgets are resolved through a pluggable
+   ``BudgetProvider``; the default returns one flat budget per pool for every user, and a
+   custom provider can vary budgets by user, role or an external service without changing
+   rules.

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -718,8 +718,13 @@ resolved by the ordinary ``inherit`` + ``combine`` precedence and overrides the 
      trillian@vortex.org:
        max_concurrent_gpus: 4       # this user overrides the gpu pool budget
 
+Pools support ``inherits:`` for reusable policy. Mark templates ``abstract: true`` so only
+concrete pools enforce budgets. Children inherit omitted ``oversize`` fields and ``fail_open``;
+explicit values override the parent, including ``max_concurrent: 0``, ``fail_open: false``,
+and ``hard_max_cores: null`` to remove an inherited ceiling.
+
 Allowing oversize jobs
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 Some trusted (non-UDT) tools legitimately need more than the whole pool budget. A pool may
 permit such *oversize* jobs up to a small concurrency limit instead of rejecting them:
 
@@ -732,7 +737,7 @@ permit such *oversize* jobs up to a small concurrency limit instead of rejecting
        max_concurrent_cores: 32
        oversize:
          max_concurrent: 1        # at most one over-budget job at a time per user
-         hard_max_cores: 128      # but never more than this — always fail beyond it
+         hard_max_cores: 128      # maximum cores requested by one oversize job
      udt:
        scheduling:
          require:
@@ -745,6 +750,13 @@ A job whose request fits the budget is admitted normally. A job that exceeds the
 deferred otherwise, and failed outright when ``max_concurrent`` is ``0`` or the request
 exceeds a ``hard_max_*`` ceiling. Route UDTs through a pool without an oversize allowance (gate
 it on the ``tool_type_user_defined`` tag) and trusted tools through one that permits it.
+
+``oversize.max_concurrent`` counts oversize jobs, while ``oversize.hard_max_*`` limits each
+oversize job's request. These are not aggregate hard limits. Normal jobs share the
+``max_concurrent_*`` budget, and oversize jobs are counted separately: the example permits
+32 cores of normal jobs plus one 128-core oversize job, totalling 160 cores. Set
+``oversize.reserve_pool: true`` to prevent normal and oversize resource usage from sharing
+the pool; ``oversize.max_concurrent`` still limits the number of oversize jobs.
 
 .. note::
    **What a pool counts.** A pool counts the resources a job *asks for*, measured before a
@@ -772,3 +784,12 @@ it on the ``tool_type_user_defined`` tag) and trusted tools through one that per
    settings are rejected. Configure Valkey persistence and disable key eviction so a restart
    or memory pressure does not discard live allocations. Completed entries for inactive
    users remain until their next admission attempt reconciles them.
+
+.. note::
+   **Galaxy's ready window.** Galaxy selects a bounded number of the oldest ready ``new``
+   jobs per user and handler before calling TPV. A backlog of jobs deferred by one pool can
+   therefore hide later jobs that would fit another pool. Increasing ``ready_window_size``
+   can mitigate a finite backlog, but does not solve starvation for an arbitrary backlog.
+   A general solution requires Galaxy's ready-job selection to account for these deferrals;
+   resource pools do not change that query. See the `Galaxy Australia issue
+   <https://github.com/usegalaxy-au/infrastructure/issues/2254>`_.

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -676,7 +676,7 @@ means it must carry none. A pool with no tags therefore governs every job. Becau
 ranking among pools (a job either is or is not governed), ``prefer`` and ``accept`` have no
 meaning on a pool and are rejected when the config is loaded.
 The only thing that lives under ``global`` is the *infrastructure* wiring for the allocation
-store (a backend URL and TTL); the budget *policy* lives on the pool entities. Enforcement is
+store (a backend URL and connection options); the budget *policy* lives on the pool entities. Enforcement is
 automatic: no rule to attach, no helper to call.
 
 .. code-block:: yaml
@@ -688,7 +688,6 @@ automatic: no rule to attach, no helper to call.
      resource_pool_store:
        class: tpv.core.resource_pool.ValkeyAllocationStore
        url: valkey://localhost:6379/0
-       ttl: 3600
 
    pools:
      # No require tags -> governs every job (that a reject tag does not exclude).
@@ -766,3 +765,10 @@ it on the ``tool_type_user_defined`` tag) and trusted tools through one that per
    set ``fail_open: true`` on it to admit jobs during an outage instead ("when unsure, let it
    through"). Leave it off (the default) for UDT/security pools, where letting a user exceed the
    limit is worse than making them wait.
+
+.. note::
+   Allocation ledgers do not expire: jobs can remain queued or running for longer than any
+   idle timeout. Entries are removed when reconciliation observes completion. Nonzero ``ttl``
+   settings are rejected. Configure Valkey persistence and disable key eviction so a restart
+   or memory pressure does not discard live allocations. Completed entries for inactive
+   users remain until their next admission attempt reconciles them.

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -659,8 +659,10 @@ derived path instead.
 Per-user resource pools
 -----------------------
 A *resource pool* caps the aggregate cores, memory and GPUs a single user may consume across
-their concurrently active jobs. This is important when exposing User Defined Tools (UDTs),
-where one user could otherwise submit many jobs and monopolise the cluster.
+their concurrently active jobs — a general way to stop any one user from monopolising the
+cluster by submitting many jobs at once. It is particularly useful when exposing User Defined
+Tools (UDTs), where untrusted, user-authored tools make such a limit essential, but it applies
+just as well to ordinary tools.
 
 Pools are a **first-class TPV entity**, declared in a top-level ``pools:`` collection alongside
 ``tools:``, ``users:``, ``roles:`` and ``destinations:``. A pool governs a job when the job's

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -749,9 +749,11 @@ it on the ``tool_type_user_defined`` tag) and trusted tools through one that per
 .. note::
    **What a pool counts.** A pool counts the resources a job *asks for*, measured before a
    destination gets to shrink them — so a destination that caps cores does not reduce what the
-   pool charges the user. The check runs once a suitable destination is known to exist (a job
-   with nowhere to run is never counted) but before the destination is finalised, so the count
-   does not depend on which destination is chosen.
+   pool charges the user. The request is captured before destination evaluation; allocations
+   are committed only after a destination has successfully evaluated. All matching pools admit
+   the job atomically, so a rejected or deferred mapping does not leave partial reservations.
+   Accounting begins when TPV returns a destination; Galaxy may still defer dispatch afterwards
+   for its own concurrency limits or quota checks.
 
 .. note::
    Enforcement is **fail-closed**: if the allocation store cannot be reached, TPV cannot check

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -659,10 +659,11 @@ derived path instead.
 Per-user resource pools
 -----------------------
 A *resource pool* caps the aggregate cores, memory and GPUs a single user may consume across
-their concurrently active jobs — a general way to stop any one user from monopolising the
-cluster by submitting many jobs at once. It is particularly useful when exposing User Defined
-Tools (UDTs), where untrusted, user-authored tools make such a limit essential, but it applies
-just as well to ordinary tools.
+their concurrently active jobs. This bounds a user's total resource *consumption*, complementing
+Galaxy's existing concurrency limits, which bound the *number* of concurrent jobs — ten small
+jobs and ten large jobs hit the same job-count limit but tie up very different amounts of the
+cluster. Support for User Defined Tools (UDTs) was the motivating use case, but the feature
+applies to any tool.
 
 Pools are a **first-class TPV entity**, declared in a top-level ``pools:`` collection alongside
 ``tools:``, ``users:``, ``roles:`` and ``destinations:``. A pool governs a job when the job's

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -662,54 +662,54 @@ A *resource pool* caps the aggregate cores, memory and GPUs a single user may co
 their concurrently active jobs. This is important when exposing User Defined Tools (UDTs),
 where one user could otherwise submit many jobs and monopolise the cluster.
 
-Pools are declared once under ``global.resource_pools`` and enforced from a rule by calling
-``helpers.enforce_resource_pool(context, name=...)``. Because the rule can live on the
-``default`` tool (which every tool inherits), a single rule enforces a pool across *every*
-job:
+Pools are a **first-class TPV entity**, declared in a top-level ``pools:`` collection alongside
+``tools:``, ``users:``, ``roles:`` and ``destinations:``. A pool governs a job when the job's
+requested scheduling tags match the pool's tags — exactly the tag matching a destination uses.
+The only thing that lives under ``global`` is the *infrastructure* wiring for the allocation
+store (a backend URL and TTL); the budget *policy* lives on the pool entities. Enforcement is
+automatic: no rule to attach, no helper to call.
 
 .. code-block:: yaml
    :linenos:
 
    global:
-     default_inherits: default
-     resource_pools:
-       # Pluggable store. The default ValkeyAllocationStore keeps allocations in Valkey,
-       # NOT in Galaxy's database. Use InMemoryAllocationStore for a single process / tests.
-       store: tpv.core.resource_pool.ValkeyAllocationStore
-       store_options:
-         url: valkey://localhost:6379/0
-         ttl: 3600
-       pools:
-         default:
-           max_cores: 32
-           max_mem: 256          # GB, matching the TPV ``mem`` convention
-         gpu:
-           max_gpus: 2
+     # Infrastructure only. The default ValkeyAllocationStore keeps allocations in Valkey,
+     # NOT in Galaxy's database. Use InMemoryAllocationStore for a single process / tests.
+     resource_pool_store:
+       class: tpv.core.resource_pool.ValkeyAllocationStore
+       url: valkey://localhost:6379/0
+       ttl: 3600
 
-   tools:
+   pools:
+     # No require tags -> governs every job (that a reject tag does not exclude).
      default:
-       cores: 2
-       mem: cores * 3
-       rules:
-         - id: enforce_default_pool
-           if: entity.cores or entity.mem or entity.gpus
-           execute: |
-             helpers.enforce_resource_pool(context, name="default")
+       max_concurrent_cores: 32
+       max_concurrent_mem: 256      # GB, matching the TPV ``mem`` convention
+     # A second, independent pool that governs only jobs tagged ``gpu``.
+     gpu:
+       scheduling:
+         require:
+           - gpu
+       max_concurrent_gpus: 2
 
-When admitting a job would push the user over the pool budget, the job is **deferred**
-(re-queued and retried later) rather than failed. A second, independent pool is just another
-named pool and another rule — for example a GPU pool gated on ``if: entity.gpus``:
+The ``max_concurrent_*`` naming is deliberate: it keeps the per-user-aggregate budget distinct
+from a tool's per-job ``cores``/``mem``/``gpus`` request and from a destination's
+``max_accepted_*`` per-job capacity. When admitting a job would push the user over the pool
+budget, the job is **deferred** (re-queued and retried later) rather than failed.
+
+Per-user and per-role budgets fall out of the entity model — no bespoke provider. Because a
+pool sits *below* Tool/Role/User in merge order, a ``max_concurrent_*`` set on a Role or User is
+resolved by the ordinary ``inherit`` + ``combine`` precedence and overrides the pool default:
 
 .. code-block:: yaml
    :linenos:
 
-   tools:
-     default:
-       rules:
-         - id: enforce_gpu_pool
-           if: entity.gpus
-           execute: |
-             helpers.enforce_resource_pool(context, name="gpu")
+   roles:
+     power_users:
+       max_concurrent_cores: 128    # this role gets a bigger budget
+   users:
+     trillian@vortex.org:
+       max_concurrent_gpus: 4       # this user overrides the gpu pool budget
 
 Allowing oversize jobs
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -718,31 +718,41 @@ permit such *oversize* jobs up to a small concurrency limit instead of rejecting
 
 .. code-block:: yaml
    :linenos:
-   :emphasize-lines: 6,7,8,9
+   :emphasize-lines: 5,6,7,8
 
-   global:
-     resource_pools:
-       pools:
-         general:
-           max_cores: 32
-           oversize:
-             max_concurrent: 1     # at most one over-budget job at a time per user
-             hard_max_cores: 128   # but never more than this — always fail beyond it
-         udt:
-           max_cores: 16
-           # no `oversize` block (max_concurrent defaults to 0): over-budget UDT jobs fail
+   pools:
+     general:
+       max_concurrent_cores: 32
+       oversize:
+         max_concurrent: 1        # at most one over-budget job at a time per user
+         hard_max_cores: 128      # but never more than this — always fail beyond it
+     udt:
+       scheduling:
+         require:
+           - tool_type_user_defined
+       max_concurrent_cores: 16
+       # no `oversize` block (max_concurrent defaults to 0): over-budget UDT jobs fail
 
 A job whose request fits the budget is admitted normally. A job that exceeds the budget is
 *oversize*: it is admitted only while fewer than ``max_concurrent`` oversize jobs are running,
 deferred otherwise, and failed outright when ``max_concurrent`` is ``0`` or the request
-exceeds a ``hard_max_*`` ceiling. Route UDTs through a pool without an oversize allowance, and
-trusted tools through one that permits it, by attaching the appropriate rule (e.g. gate UDTs
-on the ``tool_type_user_defined`` tag).
+exceeds a ``hard_max_*`` ceiling. Route UDTs through a pool without an oversize allowance (gate
+it on the ``tool_type_user_defined`` tag) and trusted tools through one that permits it.
 
 .. note::
-   Enforcement is **fail-closed**: if the allocation store cannot be reached, pool-governed
-   jobs are deferred rather than admitted, so an outage never silently bypasses the limits.
-   Treat Valkey as a scheduling dependency. Budgets are resolved through a pluggable
-   ``BudgetProvider``; the default returns one flat budget per pool for every user, and a
-   custom provider can vary budgets by user, role or an external service without changing
-   rules.
+   **What a pool counts.** A pool counts the resources a job *asks for*, measured before a
+   destination gets to shrink them — so a destination that caps cores does not reduce what the
+   pool charges the user. The check runs once a suitable destination is known to exist (a job
+   with nowhere to run is never counted) but before the destination is finalised, so the count
+   does not depend on which destination is chosen.
+
+.. note::
+   Enforcement is **fail-closed**: if the allocation store cannot be reached, TPV cannot check
+   how much the user is already using, so it plays it safe and **defers** the job rather than
+   admitting one that might blow past the budget (fail-closed = "when unsure, say no"). This
+   means an outage never silently bypasses the limits — but it also means **Valkey is a
+   scheduling dependency**: because the ``default`` pool governs every job, a Valkey outage will
+   defer every governed job on the instance. If that trade-off is too strict for a given pool,
+   set ``fail_open: true`` on it to admit jobs during an outage instead ("when unsure, let it
+   through"). Leave it off (the default) for UDT/security pools, where letting a user exceed the
+   limit is worse than making them wait.

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -654,3 +654,95 @@ This recipe requires Galaxy's ``job_working_directory`` job-concern support
 `20062 <https://github.com/galaxyproject/galaxy/pull/20062>`_).  Without that
 change, the param is still set by TPV but Galaxy will use the object-store
 derived path instead.
+
+
+Per-user resource pools
+-----------------------
+A *resource pool* caps the aggregate cores, memory and GPUs a single user may consume across
+their concurrently active jobs. This is important when exposing User Defined Tools (UDTs),
+where one user could otherwise submit many jobs and monopolise the cluster.
+
+Pools are declared once under ``global.resource_pools`` and enforced from a rule by calling
+``helpers.enforce_resource_pool(context, name=...)``. Because the rule can live on the
+``default`` tool (which every tool inherits), a single rule enforces a pool across *every*
+job:
+
+.. code-block:: yaml
+   :linenos:
+
+   global:
+     default_inherits: default
+     resource_pools:
+       # Pluggable store. The default ValkeyAllocationStore keeps allocations in Valkey,
+       # NOT in Galaxy's database. Use InMemoryAllocationStore for a single process / tests.
+       store: tpv.core.resource_pool.ValkeyAllocationStore
+       store_options:
+         url: valkey://localhost:6379/0
+         ttl: 3600
+       pools:
+         default:
+           max_cores: 32
+           max_mem: 256          # GB, matching the TPV ``mem`` convention
+         gpu:
+           max_gpus: 2
+
+   tools:
+     default:
+       cores: 2
+       mem: cores * 3
+       rules:
+         - id: enforce_default_pool
+           if: entity.cores or entity.mem or entity.gpus
+           execute: |
+             helpers.enforce_resource_pool(context, name="default")
+
+When admitting a job would push the user over the pool budget, the job is **deferred**
+(re-queued and retried later) rather than failed. A second, independent pool is just another
+named pool and another rule — for example a GPU pool gated on ``if: entity.gpus``:
+
+.. code-block:: yaml
+   :linenos:
+
+   tools:
+     default:
+       rules:
+         - id: enforce_gpu_pool
+           if: entity.gpus
+           execute: |
+             helpers.enforce_resource_pool(context, name="gpu")
+
+Allowing oversize jobs
+~~~~~~~~~~~~~~~~~~~~~~~~
+Some trusted (non-UDT) tools legitimately need more than the whole pool budget. A pool may
+permit such *oversize* jobs up to a small concurrency limit instead of rejecting them:
+
+.. code-block:: yaml
+   :linenos:
+   :emphasize-lines: 6,7,8,9
+
+   global:
+     resource_pools:
+       pools:
+         general:
+           max_cores: 32
+           oversize:
+             max_concurrent: 1     # at most one over-budget job at a time per user
+             hard_max_cores: 128   # but never more than this — always fail beyond it
+         udt:
+           max_cores: 16
+           # no `oversize` block (max_concurrent defaults to 0): over-budget UDT jobs fail
+
+A job whose request fits the budget is admitted normally. A job that exceeds the budget is
+*oversize*: it is admitted only while fewer than ``max_concurrent`` oversize jobs are running,
+deferred otherwise, and failed outright when ``max_concurrent`` is ``0`` or the request
+exceeds a ``hard_max_*`` ceiling. Route UDTs through a pool without an oversize allowance, and
+trusted tools through one that permits it, by attaching the appropriate rule (e.g. gate UDTs
+on the ``tool_type_user_defined`` tag).
+
+.. note::
+   Enforcement is **fail-closed**: if the allocation store cannot be reached, pool-governed
+   jobs are deferred rather than admitted, so an outage never silently bypasses the limits.
+   Treat Valkey as a scheduling dependency. Budgets are resolved through a pluggable
+   ``BudgetProvider``; the default returns one flat budget per pool for every user, and a
+   custom provider can vary budgets by user, role or an external service without changing
+   rules.

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -667,14 +667,12 @@ applies to any tool.
 
 Pools are a **first-class TPV entity**, declared in a top-level ``pools:`` collection alongside
 ``tools:``, ``users:``, ``roles:`` and ``destinations:``. A pool governs a job when the job's
-tags satisfy the pool's ``scheduling`` tags. These are the same ``require``/``reject`` tags you
-already use on destinations, with one difference to hold in mind: **a pool behaves like a
-destination that accepts every tag.** A job's own ``require`` tags describe what it needs from a
-destination and are always considered satisfied by a pool, so they never exempt the job. Only
-the pool's side decides -- ``require`` means the job must carry all of those tags, ``reject``
-means it must carry none. A pool with no tags therefore governs every job. Because there is no
-ranking among pools (a job either is or is not governed), ``prefer`` and ``accept`` have no
-meaning on a pool and are rejected when the config is loaded.
+positive scheduling tags (``require``, ``prefer``, or ``accept``) contain all the pool's
+``require`` tags and none of its ``reject`` tags. A job's unrelated routing requirements do
+not exclude it from a pool; an untagged pool governs every job. Tags that the job rejects do
+not describe its requested capabilities and do not participate in pool selection. Because
+there is no ranking among pools, ``prefer`` and ``accept`` have no meaning on a pool and are
+rejected when the config is loaded.
 The only thing that lives under ``global`` is the *infrastructure* wiring for the allocation
 store (a backend URL and connection options); the budget *policy* lives on the pool entities. Enforcement is
 automatic: no rule to attach, no helper to call.

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -667,7 +667,14 @@ applies to any tool.
 
 Pools are a **first-class TPV entity**, declared in a top-level ``pools:`` collection alongside
 ``tools:``, ``users:``, ``roles:`` and ``destinations:``. A pool governs a job when the job's
-requested scheduling tags match the pool's tags — exactly the tag matching a destination uses.
+tags satisfy the pool's ``scheduling`` tags. These are the same ``require``/``reject`` tags you
+already use on destinations, with one difference to hold in mind: **a pool behaves like a
+destination that accepts every tag.** A job's own ``require`` tags describe what it needs from a
+destination and are always considered satisfied by a pool, so they never exempt the job. Only
+the pool's side decides -- ``require`` means the job must carry all of those tags, ``reject``
+means it must carry none. A pool with no tags therefore governs every job. Because there is no
+ranking among pools (a job either is or is not governed), ``prefer`` and ``accept`` have no
+meaning on a pool and are rejected when the config is loaded.
 The only thing that lives under ``global`` is the *infrastructure* wiring for the allocation
 store (a backend URL and TTL); the budget *policy* lives on the pool entities. Enforcement is
 automatic: no rule to attach, no helper to call.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,19 @@ cli = [
   "total-perspective-vortex",
   "galaxy"
 ]
+# Required by the Valkey-backed per-user resource pools (see docs: Per-user resource pools).
+# redis-py speaks the Valkey wire protocol.
+resource-pools = [
+  "redis>=5.3.0",
+]
 test = [
   "total-perspective-vortex[cli]",
+  "total-perspective-vortex[resource-pools]",
   "pytest",
   "responses",
+  # Lets the resource-pool store contract test run the real Valkey adapter (Lua script)
+  # without a live server; the test skips gracefully if this is absent.
+  "fakeredis[lua]",
   "tox>=2.9.1",
   "coverage>=4.4.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ test = [
   "pytest",
   "responses",
   # Lets the resource-pool store contract test run the real Valkey adapter (Lua script)
-  # without a live server; the test skips gracefully if this is absent.
+  # without a live server. This is required: the production Lua path must be tested.
   "fakeredis[lua]",
   "tox>=2.9.1",
   "coverage>=4.4.1",

--- a/tests/fixtures/mapping-resource-pool-dead-store.yml
+++ b/tests/fixtures/mapping-resource-pool-dead-store.yml
@@ -1,0 +1,6 @@
+# Overlay for mapping-resource-pool.yml: point the store at a Valkey nothing is listening on.
+# A dry run must still map, because a dry run never touches the configured store.
+global:
+  resource_pool_store:
+    class: tpv.core.resource_pool.ValkeyAllocationStore
+    url: valkey://127.0.0.1:1/0

--- a/tests/fixtures/mapping-resource-pool-no-store.yml
+++ b/tests/fixtures/mapping-resource-pool-no-store.yml
@@ -1,0 +1,16 @@
+# Declares pool policy but no global.resource_pool_store. The mapper rejects this so that
+# enforcement can never be silently disabled by omission; a dry run must surface the same error.
+pools:
+  default:
+    max_concurrent_cores: 32
+
+tools:
+  bigtool:
+    cores: 64
+    mem: 64
+
+destinations:
+  local:
+    runner: local
+    max_accepted_cores: 256
+    max_accepted_mem: 1024

--- a/tests/fixtures/mapping-resource-pool.yml
+++ b/tests/fixtures/mapping-resource-pool.yml
@@ -1,21 +1,44 @@
 global:
   default_inherits: default
-  resource_pools:
-    # InMemoryAllocationStore keeps the ledger in-process so tests need no Valkey.
-    store: tpv.core.resource_pool.InMemoryAllocationStore
-    pools:
-      default:
-        max_cores: 32
-        max_mem: 256
-        oversize:
-          max_concurrent: 1
-          hard_max_cores: 128
-          hard_max_mem: 512
-      gpu:
-        max_gpus: 2
-      udt:
-        max_cores: 16
-        max_mem: 128
+  # Infrastructure wiring only: which allocation store to use. The InMemoryAllocationStore keeps
+  # the ledger in-process so tests need no Valkey. Pool *policy* lives in the pools: block below.
+  resource_pool_store:
+    class: tpv.core.resource_pool.InMemoryAllocationStore
+
+# First-class resource pools, alongside tools/users/roles/destinations. A pool governs a job when
+# the job's requested tags match the pool's scheduling tags (same tag match a destination uses).
+pools:
+  # Governs every non-UDT job (no require tags; rejects the udt tag so UDT jobs are handled solely
+  # by the dedicated udt pool). Trusted big tools may exceed the budget up to one oversize job.
+  default:
+    max_concurrent_cores: 32
+    max_concurrent_mem: 256
+    scheduling:
+      reject:
+        - udt
+    oversize:
+      max_concurrent: 1
+      hard_max_cores: 128
+      hard_max_mem: 512
+  # A second, GPU-dimension pool. Matches jobs that accept the 'gpu' tag.
+  gpu:
+    max_concurrent_gpus: 2
+    scheduling:
+      require:
+        - gpu
+  # UDT pool: no oversize allowance, so an over-budget job always fails. Matches 'udt' jobs only.
+  udt:
+    max_concurrent_cores: 16
+    max_concurrent_mem: 128
+    scheduling:
+      require:
+        - udt
+
+users:
+  # A trusted user with a larger budget. The override is resolved by the ordinary inherit+combine
+  # precedence (User > Role > Tool), so it wins over the pool's default max_concurrent_cores.
+  trillian@vortex.org:
+    max_concurrent_cores: 128
 
 tools:
   default:
@@ -29,11 +52,6 @@ tools:
       prefer: []
       accept: []
       reject: []
-    rules:
-      - id: enforce_default_pool
-        if: entity.cores or entity.mem or entity.gpus
-        execute: |
-          helpers.enforce_resource_pool(context, name="default")
 
   # 64 cores exceeds the default pool's 32-core budget -> oversize (allowed, throttled).
   bigtool:
@@ -50,17 +68,16 @@ tools:
     cores: 4
     mem: 600
 
-  # Exercises a second, GPU-dimension pool.
+  # Accepts the 'gpu' tag so it is governed by the gpu pool (and the default pool for cpu/mem).
   gpu_tool:
     cores: 4
     gpus: 1
-    rules:
-      - id: enforce_gpu_pool
-        if: entity.gpus
-        execute: |
-          helpers.enforce_resource_pool(context, name="gpu")
+    scheduling:
+      accept:
+        - gpu
 
-  # Routed through the 'udt' pool, which has no oversize allowance: a 64-core request fails.
+  # Accepts the 'udt' tag, routing it through the 'udt' pool (which has no oversize allowance):
+  # a 64-core request fails. inherits: ~ keeps it out of the default tool's resource defaults.
   udt_tool:
     inherits: ~
     cores: 64
@@ -68,15 +85,8 @@ tools:
     env: {}
     params: {}
     scheduling:
-      require: []
-      prefer: []
-      accept: []
-      reject: []
-    rules:
-      - id: enforce_udt_pool
-        if: entity.cores or entity.mem or entity.gpus
-        execute: |
-          helpers.enforce_resource_pool(context, name="udt")
+      accept:
+        - udt
 
 destinations:
   local:

--- a/tests/fixtures/mapping-resource-pool.yml
+++ b/tests/fixtures/mapping-resource-pool.yml
@@ -1,0 +1,93 @@
+global:
+  default_inherits: default
+  resource_pools:
+    # InMemoryAllocationStore keeps the ledger in-process so tests need no Valkey.
+    store: tpv.core.resource_pool.InMemoryAllocationStore
+    pools:
+      default:
+        max_cores: 32
+        max_mem: 256
+        oversize:
+          max_concurrent: 1
+          hard_max_cores: 128
+          hard_max_mem: 512
+      gpu:
+        max_gpus: 2
+      udt:
+        max_cores: 16
+        max_mem: 128
+
+tools:
+  default:
+    cores: 4
+    mem: cores * 2
+    gpus: 0
+    env: {}
+    params: {}
+    scheduling:
+      require: []
+      prefer: []
+      accept: []
+      reject: []
+    rules:
+      - id: enforce_default_pool
+        if: entity.cores or entity.mem or entity.gpus
+        execute: |
+          helpers.enforce_resource_pool(context, name="default")
+
+  # 64 cores exceeds the default pool's 32-core budget -> oversize (allowed, throttled).
+  bigtool:
+    cores: 64
+    mem: 64
+
+  # 200 cores exceeds the default pool's hard_max_cores of 128 -> always fails.
+  hugetool:
+    cores: 200
+    mem: 64
+
+  # 600GB mem exceeds the default pool's hard_max_mem of 512 -> always fails (cores fit).
+  bigmem_tool:
+    cores: 4
+    mem: 600
+
+  # Exercises a second, GPU-dimension pool.
+  gpu_tool:
+    cores: 4
+    gpus: 1
+    rules:
+      - id: enforce_gpu_pool
+        if: entity.gpus
+        execute: |
+          helpers.enforce_resource_pool(context, name="gpu")
+
+  # Routed through the 'udt' pool, which has no oversize allowance: a 64-core request fails.
+  udt_tool:
+    inherits: ~
+    cores: 64
+    mem: 64
+    env: {}
+    params: {}
+    scheduling:
+      require: []
+      prefer: []
+      accept: []
+      reject: []
+    rules:
+      - id: enforce_udt_pool
+        if: entity.cores or entity.mem or entity.gpus
+        execute: |
+          helpers.enforce_resource_pool(context, name="udt")
+
+destinations:
+  local:
+    runner: local
+    max_accepted_cores: 256
+    max_accepted_mem: 1024
+    max_accepted_gpus: 8
+    params:
+      native_spec: "--cores {cores} --mem {mem}"
+    scheduling:
+      require: []
+      prefer: []
+      accept: []
+      reject: []

--- a/tests/fixtures/mapping-resource-pool.yml
+++ b/tests/fixtures/mapping-resource-pool.yml
@@ -6,7 +6,7 @@ global:
     class: tpv.core.resource_pool.InMemoryAllocationStore
 
 # First-class resource pools, alongside tools/users/roles/destinations. A pool governs a job when
-# the job's tags satisfy the pool's require/reject tags (one-directional, unlike destinations).
+# its positive job tags satisfy the pool's require/reject selectors.
 pools:
   # Governs every non-UDT job (no require tags; rejects the udt tag so UDT jobs are handled solely
   # by the dedicated udt pool). Trusted big tools may exceed the budget up to one oversize job.

--- a/tests/fixtures/mapping-resource-pool.yml
+++ b/tests/fixtures/mapping-resource-pool.yml
@@ -6,7 +6,7 @@ global:
     class: tpv.core.resource_pool.InMemoryAllocationStore
 
 # First-class resource pools, alongside tools/users/roles/destinations. A pool governs a job when
-# the job's requested tags match the pool's scheduling tags (same tag match a destination uses).
+# the job's tags satisfy the pool's require/reject tags (one-directional, unlike destinations).
 pools:
   # Governs every non-UDT job (no require tags; rejects the udt tag so UDT jobs are handled solely
   # by the dedicated udt pool). Trusted big tools may exceed the budget up to one oversize job.
@@ -88,6 +88,15 @@ tools:
       accept:
         - udt
 
+  # Routing tags are ordinary in production configs. Such a job must still be governed by the
+  # untagged 'default' pool -- the pool selects jobs, it does not negotiate capabilities.
+  tagged_tool:
+    cores: 64
+    mem: 64
+    scheduling:
+      require:
+        - pulsar
+
 destinations:
   local:
     runner: local
@@ -99,5 +108,6 @@ destinations:
     scheduling:
       require: []
       prefer: []
-      accept: []
+      accept:
+        - pulsar
       reject: []

--- a/tests/fixtures/pools/data_manager_conf.xml.sample
+++ b/tests/fixtures/pools/data_manager_conf.xml.sample
@@ -1,0 +1,2 @@
+<data_managers>
+</data_managers>

--- a/tests/fixtures/pools/job_conf_pools.yml
+++ b/tests/fixtures/pools/job_conf_pools.yml
@@ -1,0 +1,15 @@
+runners:
+  local:
+    load: galaxy.jobs.runners.local:LocalJobRunner
+    workers: 4
+
+execution:
+  default: tpv_dispatcher
+  environments:
+    tpv_dispatcher:
+      runner: dynamic
+      type: python
+      function: map_tool_to_destination
+      rules_module: tpv.rules
+      tpv_config_files:
+        - tests/fixtures/pools/mapping-pools.yml

--- a/tests/fixtures/pools/mapping-pools.yml
+++ b/tests/fixtures/pools/mapping-pools.yml
@@ -1,0 +1,75 @@
+# Integration fixture: per-user pools exercised against a real Galaxy AND a real Valkey.
+#
+# The store is the production one on purpose: the Lua admit script only runs for real against a
+# real server (the parity test pins its logic against fakeredis; nothing else touches a socket),
+# and a real store lets the tests read the ledger directly and assert exact accounting.
+#
+# Each pool below reaches a distinct branch of the Lua decision:
+#   default   -- budget fit/defer, an oversize slot, hard_max rejection, terminal reconciliation
+#   gpu       -- a second key on the same job, so admission is a multi-key batch: one full pool
+#                must veto the write to every pool (check-all-then-write-all)
+#   exclusive -- reserve_pool: normal and oversize usage may not coexist, in either order
+#
+# The tests skip when nothing listens on localhost:6379, or fail in CI (TPV_TEST_REQUIRE_VALKEY).
+global:
+  default_inherits: default
+  resource_pool_store:
+    class: tpv.core.resource_pool.ValkeyAllocationStore
+    url: valkey://localhost:6379/0
+    key_prefix: tpv-integration-test:pool
+
+pools:
+  default:
+    max_concurrent_cores: 8      # exactly two 4-core jobs at once
+    oversize:
+      max_concurrent: 1          # one over-budget job at a time...
+      hard_max_cores: 16         # ...and never one above this
+    scheduling:
+      reject: [exclusive]        # keep the exclusive pool's jobs out of this ledger
+
+  gpu:
+    max_concurrent_gpus: 1
+    scheduling:
+      require: [gpu]
+
+  exclusive:
+    max_concurrent_cores: 8
+    oversize:
+      max_concurrent: 1
+      hard_max_cores: 16
+      reserve_pool: true         # an oversize job holds the pool alone
+    scheduling:
+      require: [exclusive]
+
+tools:
+  default:
+    cores: 1
+    mem: 1
+  pool_sleep:                    # fits the default budget: two at once
+    cores: 4
+  pool_sleep_oversize:           # exceeds the default budget, within its ceiling: one at a time
+    cores: 12
+  pool_sleep_huge:               # exceeds the ceiling: can never be scheduled
+    cores: 200
+  pool_sleep_gpu:                # governed by default AND gpu
+    cores: 4
+    gpus: 1
+    scheduling:
+      accept: [gpu]
+  pool_sleep_exclusive:          # a normal job in the exclusive pool
+    cores: 4
+    scheduling:
+      accept: [exclusive]
+  pool_sleep_exclusive_oversize: # an oversize job in the exclusive pool
+    cores: 12
+    scheduling:
+      accept: [exclusive]
+
+destinations:
+  local:
+    runner: local
+    max_accepted_cores: 256      # large enough that the 200-core job reaches pool admission
+    max_accepted_mem: 64
+    max_accepted_gpus: 4
+    scheduling:
+      accept: [gpu, exclusive]

--- a/tests/fixtures/pools/pool_sleep.xml
+++ b/tests/fixtures/pools/pool_sleep.xml
@@ -1,0 +1,11 @@
+<tool id="pool_sleep" name="pool_sleep" version="0.1.0" profile="16.04">
+    <!-- Holds its resource-pool allocation for a controllable time. TPV assigns the resources
+         by tool id (see mapping-pools.yml); the tool itself is identical for every id. -->
+    <command><![CDATA[sleep '$seconds' && echo done > '$out']]></command>
+    <inputs>
+        <param name="seconds" type="integer" value="1" label="Seconds to sleep" />
+    </inputs>
+    <outputs>
+        <data name="out" format="txt" />
+    </outputs>
+</tool>

--- a/tests/fixtures/pools/pool_sleep_exclusive.xml
+++ b/tests/fixtures/pools/pool_sleep_exclusive.xml
@@ -1,0 +1,11 @@
+<tool id="pool_sleep_exclusive" name="pool_sleep_exclusive" version="0.1.0" profile="16.04">
+    <!-- Holds its resource-pool allocation for a controllable time. TPV assigns the resources
+         by tool id (see mapping-pools.yml); the tool itself is identical for every id. -->
+    <command><![CDATA[sleep '$seconds' && echo done > '$out']]></command>
+    <inputs>
+        <param name="seconds" type="integer" value="1" label="Seconds to sleep" />
+    </inputs>
+    <outputs>
+        <data name="out" format="txt" />
+    </outputs>
+</tool>

--- a/tests/fixtures/pools/pool_sleep_exclusive_oversize.xml
+++ b/tests/fixtures/pools/pool_sleep_exclusive_oversize.xml
@@ -1,0 +1,11 @@
+<tool id="pool_sleep_exclusive_oversize" name="pool_sleep_exclusive_oversize" version="0.1.0" profile="16.04">
+    <!-- Holds its resource-pool allocation for a controllable time. TPV assigns the resources
+         by tool id (see mapping-pools.yml); the tool itself is identical for every id. -->
+    <command><![CDATA[sleep '$seconds' && echo done > '$out']]></command>
+    <inputs>
+        <param name="seconds" type="integer" value="1" label="Seconds to sleep" />
+    </inputs>
+    <outputs>
+        <data name="out" format="txt" />
+    </outputs>
+</tool>

--- a/tests/fixtures/pools/pool_sleep_gpu.xml
+++ b/tests/fixtures/pools/pool_sleep_gpu.xml
@@ -1,0 +1,11 @@
+<tool id="pool_sleep_gpu" name="pool_sleep_gpu" version="0.1.0" profile="16.04">
+    <!-- Holds its resource-pool allocation for a controllable time. TPV assigns the resources
+         by tool id (see mapping-pools.yml); the tool itself is identical for every id. -->
+    <command><![CDATA[sleep '$seconds' && echo done > '$out']]></command>
+    <inputs>
+        <param name="seconds" type="integer" value="1" label="Seconds to sleep" />
+    </inputs>
+    <outputs>
+        <data name="out" format="txt" />
+    </outputs>
+</tool>

--- a/tests/fixtures/pools/pool_sleep_huge.xml
+++ b/tests/fixtures/pools/pool_sleep_huge.xml
@@ -1,0 +1,11 @@
+<tool id="pool_sleep_huge" name="pool_sleep_huge" version="0.1.0" profile="16.04">
+    <!-- Holds its resource-pool allocation for a controllable time. TPV assigns the resources
+         by tool id (see mapping-pools.yml); the tool itself is identical for every id. -->
+    <command><![CDATA[sleep '$seconds' && echo done > '$out']]></command>
+    <inputs>
+        <param name="seconds" type="integer" value="1" label="Seconds to sleep" />
+    </inputs>
+    <outputs>
+        <data name="out" format="txt" />
+    </outputs>
+</tool>

--- a/tests/fixtures/pools/pool_sleep_oversize.xml
+++ b/tests/fixtures/pools/pool_sleep_oversize.xml
@@ -1,0 +1,11 @@
+<tool id="pool_sleep_oversize" name="pool_sleep_oversize" version="0.1.0" profile="16.04">
+    <!-- Holds its resource-pool allocation for a controllable time. TPV assigns the resources
+         by tool id (see mapping-pools.yml); the tool itself is identical for every id. -->
+    <command><![CDATA[sleep '$seconds' && echo done > '$out']]></command>
+    <inputs>
+        <param name="seconds" type="integer" value="1" label="Seconds to sleep" />
+    </inputs>
+    <outputs>
+        <data name="out" format="txt" />
+    </outputs>
+</tool>

--- a/tests/fixtures/pools/tool_conf_pools.xml
+++ b/tests/fixtures/pools/tool_conf_pools.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<toolbox tool_path="${tool_conf_dir}" is_shed_conf="false">
+  <tool file="pool_sleep.xml" />
+  <tool file="pool_sleep_oversize.xml" />
+  <tool file="pool_sleep_huge.xml" />
+  <tool file="pool_sleep_gpu.xml" />
+  <tool file="pool_sleep_exclusive.xml" />
+  <tool file="pool_sleep_exclusive_oversize.xml" />
+</toolbox>

--- a/tests/fixtures/pools/tool_data_tables.xml.sample
+++ b/tests/fixtures/pools/tool_data_tables.xml.sample
@@ -1,0 +1,2 @@
+<tables>
+</tables>

--- a/tests/test_dryrunner_resource_pool.py
+++ b/tests/test_dryrunner_resource_pool.py
@@ -1,0 +1,60 @@
+import os
+import unittest
+
+from tpv.commands.dryrunner import TPVDryRunner
+from tpv.commands.test import mock_galaxy
+from tpv.core.resource_pool import InMemoryAllocationStore
+from tpv.rules import gateway
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+POOL_CONFIG = os.path.join(FIXTURES, "mapping-resource-pool.yml")
+DEAD_STORE_OVERLAY = os.path.join(FIXTURES, "mapping-resource-pool-dead-store.yml")
+JOB_CONF = os.path.join(FIXTURES, "job_conf_dry_run.yml")
+
+
+class TestMockJob(unittest.TestCase):
+    def test_jobs_get_distinct_default_ids(self):
+        # Pool admission keys the ledger by job id, so a mock job must always have one.
+        a, b = mock_galaxy.Job(), mock_galaxy.Job()
+        self.assertIsInstance(a.id, int)
+        self.assertNotEqual(a.id, b.id)
+
+
+class TestDryRunResourcePools(unittest.TestCase):
+    def _run(self, tool, user, confs, explain=False):
+        runner = TPVDryRunner.from_params(job_conf=JOB_CONF, tool_id=tool, user_email=user, tpv_confs=confs)
+        return runner.run(explain=explain)
+
+    def test_dry_run_maps_a_pooled_config(self):
+        destination, _ = self._run("bigtool", "arthur@vortex.org", [POOL_CONFIG])
+        self.assertEqual(destination.id, "local")
+
+    def test_dry_run_never_touches_the_configured_store(self):
+        # The configured store is a Valkey nothing listens on. If the dry run consulted it, the
+        # job would be deferred fail-closed (or the run would error); an admin's dry run must
+        # neither depend on nor write to production accounting.
+        destination, _ = self._run("bigtool", "arthur@vortex.org", [POOL_CONFIG, DEAD_STORE_OVERLAY])
+        self.assertEqual(destination.id, "local")
+        store = gateway.ACTIVE_DESTINATION_MAPPERS["tpv_dispatcher"].resource_pools.store
+        self.assertIsInstance(store, InMemoryAllocationStore)
+
+    def test_dry_run_still_reports_pools_without_a_store(self):
+        # Swapping in an in-memory store must not hide the misconfiguration the mapper rejects.
+        no_store = os.path.join(FIXTURES, "mapping-resource-pool-no-store.yml")
+        with self.assertRaisesRegex(ValueError, "resource_pool_store"):
+            self._run("bigtool", "arthur@vortex.org", [no_store])
+
+    def test_explain_reports_which_pools_govern_the_job_and_why(self):
+        _, collector = self._run("bigtool", "arthur@vortex.org", [POOL_CONFIG], explain=True)
+        trace = collector.render()
+        self.assertIn("Resource Pools", trace)
+        # bigtool is 64 cores against a 32-core budget: governed by 'default', classified oversize.
+        self.assertIn("default", trace)
+        self.assertIn("oversize", trace.lower())
+        self.assertIn("32", trace)
+
+    def test_explain_reports_a_permanently_rejected_request(self):
+        # hugetool (200 cores) exceeds the oversize ceiling and can never be scheduled.
+        destination, collector = self._run("hugetool", "arthur@vortex.org", [POOL_CONFIG], explain=True)
+        self.assertIsNone(destination)
+        self.assertIn("can never be scheduled", collector.render())

--- a/tests/test_mapper_resource_pool_integration.py
+++ b/tests/test_mapper_resource_pool_integration.py
@@ -1,0 +1,260 @@
+"""Resource pools against a real Galaxy and a real Valkey.
+
+Every other pool test runs against mock_galaxy, and the Valkey adapter is otherwise exercised
+only against fakeredis. These run a live Galaxy with an in-process job handler and the
+production ValkeyAllocationStore, so the Lua admit script runs for real, and the tests can read
+the ledger directly and assert exact accounting rather than infer it from job states.
+
+Each test reaches a distinct branch of the Lua decision (see mapping-pools.yml):
+budget fit and deferral, the oversize slot, hard_max rejection before any write, reserve_pool
+in both directions, a full pool vetoing the multi-key write, terminal reconciliation, PERSIST,
+and per-user isolation.
+
+Requires a Valkey on localhost:6379:  docker run -d --rm -p 6379:6379 valkey/valkey:8
+The tests skip without one, except in CI (TPV_TEST_REQUIRE_VALKEY set), where they fail.
+"""
+
+import os
+import time
+
+import pytest
+from galaxy.webapps.base import webapp
+from galaxy_test.base.populators import DatasetPopulator
+from galaxy_test.driver.integration_util import IntegrationTestCase
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "pools")
+VALKEY_URL = "redis://localhost:6379/0"
+KEY_PREFIX = "tpv-integration-test:pool"  # must match mapping-pools.yml
+BUDGET_CORES = 8  # default pool, must match mapping-pools.yml
+JOB_CORES = 4  # pool_sleep, must match mapping-pools.yml
+ACTIVE = {"queued", "running"}
+
+
+def _valkey():
+    import redis
+
+    return redis.from_url(VALKEY_URL, decode_responses=True, socket_connect_timeout=1)
+
+
+def _require_or_skip_valkey():
+    try:
+        _valkey().ping()
+    except Exception as e:  # noqa: BLE001 - any failure to reach the server means "not available"
+        if os.environ.get("TPV_TEST_REQUIRE_VALKEY"):
+            raise AssertionError(f"TPV_TEST_REQUIRE_VALKEY is set but Valkey is unreachable: {e}") from e
+        pytest.skip(
+            f"Valkey not reachable at {VALKEY_URL} ({e}); start one with: docker run -d --rm -p 6379:6379 valkey/valkey:8"
+        )
+
+
+# Under xdist every worker starts its own Galaxy with its own database, so user and job ids
+# collide across workers (each Galaxy's first user and first job are id 1). Sharing one Valkey
+# between them would mix ledgers and let one worker's setUp flush another's mid-test. Pin the
+# whole class to a single worker; tox runs with --dist=loadgroup so this marker is honoured.
+@pytest.mark.xdist_group("valkey")
+class TestResourcePoolIntegration(IntegrationTestCase):
+    default_tool_conf = os.path.join(FIXTURES, "tool_conf_pools.xml")
+
+    @classmethod
+    def setUpClass(cls):
+        _require_or_skip_valkey()  # before the (expensive) Galaxy start-up
+        super().setUpClass()
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["config_dir"] = FIXTURES
+        config["job_config_file"] = "job_conf_pools.yml"
+        # Galaxy is a wheel in CI, not a checkout, so the sample configs it would otherwise
+        # default to (lib/galaxy/config/sample/...) do not exist; point it at empty ones.
+        config["tool_data_path"] = FIXTURES
+        config["tool_data_table_config_path"] = os.path.join(FIXTURES, "tool_data_tables.xml.sample")
+        config["data_manager_config_file"] = os.path.join(FIXTURES, "data_manager_conf.xml.sample")
+        config["template_path"] = os.path.abspath(os.path.join(os.path.dirname(webapp.__file__), "templates"))
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.valkey = _valkey()
+        for key in self.valkey.scan_iter(f"{KEY_PREFIX}:*"):  # isolate tests from each other
+            self.valkey.delete(key)
+
+    # -- helpers -------------------------------------------------------------------------------
+
+    def _submit(self, history_id, seconds, tool_id="pool_sleep"):
+        response = self.dataset_populator.run_tool(tool_id, {"seconds": seconds}, history_id)
+        return response["jobs"][0]["id"], response["outputs"][0]["id"]
+
+    def _decode(self, encoded_id):
+        return self._test_driver.app.security.decode_id(encoded_id)
+
+    def _state(self, job_id):
+        return self.dataset_populator.get_job_details(job_id).json()["state"]
+
+    def _wait_for_state(self, job_id, states, timeout=60):
+        deadline = time.time() + timeout
+        state = None
+        while time.time() < deadline:
+            state = self._state(job_id)
+            if state in states:
+                return state
+            time.sleep(0.5)
+        raise AssertionError(f"job {job_id} did not reach {states} within {timeout}s (last state: {state})")
+
+    def _assert_deferred(self, job_id, seconds=4):
+        """A deferred job is left in 'new' by the handler: never queued, never started."""
+        for _ in range(seconds * 2):
+            time.sleep(0.5)
+            assert self._state(job_id) == "new", f"job {job_id} was admitted while its pool was full"
+
+    def _wait_all_ok(self, *job_ids, timeout=60):
+        for job_id in job_ids:
+            self.dataset_populator.wait_for_job(job_id, assert_ok=True, timeout=timeout)
+
+    def _current_user_id(self):
+        return self._decode(self.dataset_populator._get("users/current").json()["id"])
+
+    def _ledger(self, user_id, pool="default"):
+        """{job_id: {"cores", "mem", "gpus", "kind"}} straight from Valkey."""
+        raw = self.valkey.hgetall(f"{KEY_PREFIX}:{pool}:user:{{{user_id}}}")
+        ledger = {}
+        for job_id, value in raw.items():
+            cores, mem, gpus, kind = value.split("|")
+            ledger[int(job_id)] = {"cores": float(cores), "mem": float(mem), "gpus": float(gpus), "kind": kind}
+        return ledger
+
+    # -- budget --------------------------------------------------------------------------------
+
+    @pytest.mark.slow
+    def test_budget_admits_exactly_two_at_a_time_across_five_jobs(self):
+        user_id = self._current_user_id()
+        with self.dataset_populator.test_history() as history_id:
+            jobs = [self._submit(history_id, seconds=6)[0] for _ in range(5)]
+
+            # Sample job states and the ledger together until every job is done: never more than
+            # two active, never more than 8 cores recorded -- and at some point both slots in
+            # use, or the pool is over-throttling.
+            saw_full_pool = False
+            deadline = time.time() + 120
+            while time.time() < deadline:
+                states = [self._state(j) for j in jobs]
+                ledger = self._ledger(user_id)
+                active = sum(s in ACTIVE for s in states)
+                recorded = sum(e["cores"] for e in ledger.values())
+                assert active <= BUDGET_CORES // JOB_CORES, f"{active} jobs active at once; states={states}"
+                assert recorded <= BUDGET_CORES, f"ledger over budget: {ledger}"
+                saw_full_pool = saw_full_pool or (active == 2 and recorded == BUDGET_CORES)
+                if all(s == "ok" for s in states):
+                    break
+                assert not any(s in {"error", "failed"} for s in states), states
+                time.sleep(0.5)
+            else:
+                raise AssertionError(f"jobs did not all finish: {[self._state(j) for j in jobs]}")
+            assert saw_full_pool, "never observed both slots in use: the pool is over-throttling"
+
+            # Finished jobs stay recorded until the next admission for this user reconciles them
+            # against the job table. That admission must drop all five and record only the new
+            # job -- and the key must have survived to be reconciled (no TTL).
+            last, _ = self._submit(history_id, seconds=1)
+            self._wait_all_ok(last)
+            assert set(self._ledger(user_id)) == {self._decode(last)}
+
+    @pytest.mark.slow
+    def test_pools_are_per_user(self):
+        with self.dataset_populator.test_history() as history_a:
+            a_jobs = [self._submit(history_a, seconds=12)[0] for _ in range(2)]
+            for j in a_jobs:
+                self._wait_for_state(j, {"running"})
+            a_blocked, _ = self._submit(history_a, seconds=1)  # A's pool is full
+
+            # User B's identical job is admitted immediately: A's usage is not B's.
+            with self._different_user("pool-user-b@vortex.org"):
+                populator_b = DatasetPopulator(self.galaxy_interactor)
+                with populator_b.test_history() as history_b:
+                    b_job = populator_b.run_tool("pool_sleep", {"seconds": 1}, history_b)["jobs"][0]["id"]
+                    populator_b.wait_for_job(b_job, assert_ok=True, timeout=30)
+
+            assert self._state(a_blocked) == "new", "user A's job ran while A's pool was full"
+            assert len(list(self.valkey.scan_iter(f"{KEY_PREFIX}:default:user:*"))) == 2, "one ledger per user"
+            self._wait_all_ok(*a_jobs, a_blocked)
+
+    # -- oversize ------------------------------------------------------------------------------
+
+    @pytest.mark.slow
+    def test_oversize_slot_admits_one_over_budget_job_then_defers_the_next(self):
+        user_id = self._current_user_id()
+        with self.dataset_populator.test_history() as history_id:
+            first, _ = self._submit(history_id, seconds=10, tool_id="pool_sleep_oversize")
+            self._wait_for_state(first, {"running"})
+            assert self._ledger(user_id)[self._decode(first)]["kind"] == "oversize"
+
+            second, _ = self._submit(history_id, seconds=1, tool_id="pool_sleep_oversize")
+            self._assert_deferred(second)  # max_concurrent: 1
+            assert set(self._ledger(user_id)) == {self._decode(first)}, "a deferred job must not be recorded"
+
+            self._wait_all_ok(first, second)
+
+    @pytest.mark.slow
+    def test_request_above_the_ceiling_is_rejected_before_any_write(self):
+        with self.dataset_populator.test_history() as history_id:
+            job_id, output_id = self._submit(history_id, seconds=1, tool_id="pool_sleep_huge")
+            state = self._wait_for_state(job_id, {"error", "failed", "ok", "running"})
+            assert state == "error", f"a request that can never fit must fail permanently, got {state}"
+            # Galaxy's handler turns JobMappingException.failure_message into job_wrapper.fail(),
+            # which records it on the output dataset -- that is where the user sees why.
+            output = self.dataset_populator.get_history_dataset_details(
+                history_id, dataset_id=output_id, assert_ok=False, wait=False
+            )
+            assert "can never be scheduled" in output["misc_info"], output
+            assert self._ledger(self._current_user_id()) == {}, "rejection must happen before any write"
+
+    # -- reserve_pool --------------------------------------------------------------------------
+
+    @pytest.mark.slow
+    def test_reserve_pool_defers_a_normal_job_while_an_oversize_job_runs(self):
+        with self.dataset_populator.test_history() as history_id:
+            big, _ = self._submit(history_id, seconds=8, tool_id="pool_sleep_exclusive_oversize")
+            self._wait_for_state(big, {"running"})
+            small, _ = self._submit(history_id, seconds=1, tool_id="pool_sleep_exclusive")
+            self._assert_deferred(small)  # fits the budget, but the pool is reserved
+            self._wait_all_ok(big, small)
+
+    @pytest.mark.slow
+    def test_reserve_pool_defers_an_oversize_job_while_a_normal_job_runs(self):
+        with self.dataset_populator.test_history() as history_id:
+            small, _ = self._submit(history_id, seconds=8, tool_id="pool_sleep_exclusive")
+            self._wait_for_state(small, {"running"})
+            big, _ = self._submit(history_id, seconds=1, tool_id="pool_sleep_exclusive_oversize")
+            self._assert_deferred(big)  # the oversize slot is free, but the pool is not empty
+            self._wait_all_ok(small, big)
+
+    # -- multi-key atomicity -------------------------------------------------------------------
+
+    @pytest.mark.slow
+    def test_a_full_pool_vetoes_the_write_to_every_pool_in_the_batch(self):
+        """A GPU job is governed by both 'default' and 'gpu'. With the gpu pool full and the
+        default pool half empty, the job must be deferred AND leave no trace in 'default': the
+        Lua script checks every key before writing to any, so one full pool vetoes them all."""
+        user_id = self._current_user_id()
+        with self.dataset_populator.test_history() as history_id:
+            first, _ = self._submit(history_id, seconds=10, tool_id="pool_sleep_gpu")
+            self._wait_for_state(first, {"running"})
+            first_id = self._decode(first)
+            assert set(self._ledger(user_id, "default")) == {first_id}
+            assert set(self._ledger(user_id, "gpu")) == {first_id}
+            assert self._ledger(user_id, "gpu")[first_id]["gpus"] == 1
+
+            second, _ = self._submit(history_id, seconds=6, tool_id="pool_sleep_gpu")
+            self._assert_deferred(second)
+            # The decisive check: default had room for it (4 + 4 <= 8) and must still not hold it.
+            assert set(self._ledger(user_id, "default")) == {
+                first_id
+            }, "partial write: one pool admitted a job another vetoed"
+            assert set(self._ledger(user_id, "gpu")) == {first_id}
+
+            # When the first finishes, the second is admitted to both pools in one write.
+            self._wait_all_ok(first)
+            self._wait_for_state(second, ACTIVE)
+            second_id = self._decode(second)
+            assert second_id in self._ledger(user_id, "default")
+            assert second_id in self._ledger(user_id, "gpu")
+            self._wait_all_ok(second)

--- a/tests/test_mapper_resource_pool_integration.py
+++ b/tests/test_mapper_resource_pool_integration.py
@@ -15,16 +15,19 @@ The tests skip without one, except in CI (TPV_TEST_REQUIRE_VALKEY set), where th
 """
 
 import os
+import shutil
+import tempfile
 import time
 
 import pytest
+import yaml
 from galaxy.webapps.base import webapp
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "pools")
 VALKEY_URL = "redis://localhost:6379/0"
-KEY_PREFIX = "tpv-integration-test:pool"  # must match mapping-pools.yml
+KEY_PREFIX = "tpv-integration-test:pool"  # the fixture's value; each worker derives its own from it
 BUDGET_CORES = 8  # default pool, must match mapping-pools.yml
 JOB_CORES = 4  # pool_sleep, must match mapping-pools.yml
 ACTIVE = {"queued", "running"}
@@ -47,22 +50,48 @@ def _require_or_skip_valkey():
         )
 
 
-# Under xdist every worker starts its own Galaxy with its own database, so user and job ids
-# collide across workers (each Galaxy's first user and first job are id 1). Sharing one Valkey
-# between them would mix ledgers and let one worker's setUp flush another's mid-test. Pin the
-# whole class to a single worker; tox runs with --dist=loadgroup so this marker is honoured.
-@pytest.mark.xdist_group("valkey")
 class TestResourcePoolIntegration(IntegrationTestCase):
     default_tool_conf = os.path.join(FIXTURES, "tool_conf_pools.xml")
 
     @classmethod
     def setUpClass(cls):
         _require_or_skip_valkey()  # before the (expensive) Galaxy start-up
+        cls._isolate_valkey_keys_per_worker()
         super().setUpClass()
 
     @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        shutil.rmtree(cls.config_dir, ignore_errors=True)
+
+    @classmethod
+    def _isolate_valkey_keys_per_worker(cls):
+        """Under xdist every worker runs its own Galaxy with its own database, so user and job
+        ids collide across workers (each Galaxy's first user and first job are id 1). Sharing
+        one Valkey between them would mix ledgers and let one worker's setUp flush another's
+        mid-test. Give each worker its own key_prefix: copy the fixture config with the prefix
+        patched, and a job conf pointing at the copy. The fixture file stays the readable
+        source of truth; only that one field differs."""
+        worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+        cls.key_prefix = f"{KEY_PREFIX}:{worker}"
+        cls.config_dir = tempfile.mkdtemp(prefix="tpv-pools-")
+
+        with open(os.path.join(FIXTURES, "mapping-pools.yml")) as f:
+            mapping = yaml.safe_load(f)
+        mapping["global"]["resource_pool_store"]["key_prefix"] = cls.key_prefix
+        mapping_path = os.path.join(cls.config_dir, "mapping-pools.yml")
+        with open(mapping_path, "w") as f:
+            yaml.safe_dump(mapping, f)
+
+        with open(os.path.join(FIXTURES, "job_conf_pools.yml")) as f:
+            job_conf = yaml.safe_load(f)
+        job_conf["execution"]["environments"]["tpv_dispatcher"]["tpv_config_files"] = [mapping_path]
+        with open(os.path.join(cls.config_dir, "job_conf_pools.yml"), "w") as f:
+            yaml.safe_dump(job_conf, f)
+
+    @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        config["config_dir"] = FIXTURES
+        config["config_dir"] = cls.config_dir
         config["job_config_file"] = "job_conf_pools.yml"
         # Galaxy is a wheel in CI, not a checkout, so the sample configs it would otherwise
         # default to (lib/galaxy/config/sample/...) do not exist; point it at empty ones.
@@ -75,7 +104,7 @@ class TestResourcePoolIntegration(IntegrationTestCase):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.valkey = _valkey()
-        for key in self.valkey.scan_iter(f"{KEY_PREFIX}:*"):  # isolate tests from each other
+        for key in self.valkey.scan_iter(f"{self.key_prefix}:*"):  # isolate tests from each other
             self.valkey.delete(key)
 
     # -- helpers -------------------------------------------------------------------------------
@@ -115,7 +144,7 @@ class TestResourcePoolIntegration(IntegrationTestCase):
 
     def _ledger(self, user_id, pool="default"):
         """{job_id: {"cores", "mem", "gpus", "kind"}} straight from Valkey."""
-        raw = self.valkey.hgetall(f"{KEY_PREFIX}:{pool}:user:{{{user_id}}}")
+        raw = self.valkey.hgetall(f"{self.key_prefix}:{pool}:user:{{{user_id}}}")
         ledger = {}
         for job_id, value in raw.items():
             cores, mem, gpus, kind = value.split("|")
@@ -174,7 +203,7 @@ class TestResourcePoolIntegration(IntegrationTestCase):
                     populator_b.wait_for_job(b_job, assert_ok=True, timeout=30)
 
             assert self._state(a_blocked) == "new", "user A's job ran while A's pool was full"
-            assert len(list(self.valkey.scan_iter(f"{KEY_PREFIX}:default:user:*"))) == 2, "one ledger per user"
+            assert len(list(self.valkey.scan_iter(f"{self.key_prefix}:default:user:*"))) == 2, "one ledger per user"
             self._wait_all_ok(*a_jobs, a_blocked)
 
     # -- oversize ------------------------------------------------------------------------------

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -9,10 +9,9 @@ from tpv.core.mapper import EntityToDestinationMapper
 from tpv.core.resource_pool import (
     NORMAL,
     OVERSIZE,
+    AllocationStore,
     Budget,
-    ConfigBudgetProvider,
     InMemoryAllocationStore,
-    ResourcePoolConfig,
     ResourceUsage,
     StoreUnavailable,
     ValkeyAllocationStore,
@@ -160,15 +159,22 @@ class TestAllocationStore(unittest.TestCase):
         self.assertEqual(len(self.store.read("default", 1)), 1)
 
 
-class TestBudgetProvider(unittest.TestCase):
-    def test_flat_per_pool_budget(self):
-        config = ResourcePoolConfig.model_validate(
-            {"pools": {"gpu": {"max_gpus": 2}, "cpu": {"max_cores": 16, "max_mem": 64}}}
+class TestStoreConfig(unittest.TestCase):
+    def test_builds_store_from_class_and_options(self):
+        from tpv.core.resource_pool import StoreConfig
+
+        config = StoreConfig.model_validate(
+            {"class": "tpv.core.resource_pool.InMemoryAllocationStore", "key_prefix": "custom"}
         )
-        provider = ConfigBudgetProvider(config)
-        self.assertEqual(provider.budget_for(None, "gpu"), Budget(cores=None, mem=None, gpus=2))
-        self.assertEqual(provider.budget_for(None, "cpu"), Budget(cores=16, mem=64, gpus=None))
-        self.assertEqual(provider.budget_for(None, "missing"), Budget())
+        store = config.build_store()
+        self.assertIsInstance(store, InMemoryAllocationStore)
+        # The extra option was passed through to the store constructor.
+        self.assertEqual(store.key_prefix, "custom")
+
+    def test_default_store_class_is_valkey(self):
+        from tpv.core.resource_pool import StoreConfig
+
+        self.assertEqual(StoreConfig().store_class, "tpv.core.resource_pool.ValkeyAllocationStore")
 
 
 class TestTerminalJobIds(unittest.TestCase):
@@ -308,6 +314,83 @@ class TestResourcePoolMapping(unittest.TestCase):
         with self.assertRaises(JobNotReadyException):
             mapper.map_to_destination(self._app(), mock_galaxy.Tool("gpu_tool"), user, self._job(16))
 
+    def test_user_budget_override_wins_over_pool_default(self):
+        # trillian's user entity raises max_concurrent_cores to 128; combine resolves it over the
+        # default pool's 32, so two 64-core bigtool jobs are admitted as *normal* (not oversize).
+        mapper = self._mapper()
+        trillian = mock_galaxy.User("trillian", "trillian@vortex.org", id=4)
+        d1 = mapper.map_to_destination(self._app(), mock_galaxy.Tool("bigtool"), trillian, self._job(30))
+        d2 = mapper.map_to_destination(self._app(), mock_galaxy.Tool("bigtool"), trillian, self._job(31))
+        self.assertEqual((d1.id, d2.id), ("local", "local"))
+        ledger = mapper.resource_pools.store.read("default", trillian.id)
+        self.assertEqual({jid: kind for jid, (_, kind) in ledger.items()}, {30: NORMAL, 31: NORMAL})
+
+
+class _RaisingStore(AllocationStore):
+    """A store whose backend is always unreachable, to exercise the fail-closed path."""
+
+    def read(self, pool, user_id):
+        raise StoreUnavailable("backend down")
+
+    def admit(self, *args, **kwargs):
+        raise StoreUnavailable("backend down")
+
+
+class TestResourcePoolBranches(unittest.TestCase):
+    """Covers the enforcement branches that carry the safety story: fail-closed, fail_open,
+    anonymous no-op and pools-disabled no-op."""
+
+    def _mapper(self):
+        return EntityToDestinationMapper(TPVConfigLoader.from_url_or_path(FIXTURE))
+
+    @staticmethod
+    def _job(job_id):
+        job = mock_galaxy.Job()
+        job.id = job_id
+        return job
+
+    def _app(self):
+        return mock_galaxy.App(create_model=True)
+
+    def test_store_unavailable_defers_fail_closed(self):
+        mapper = self._mapper()
+        mapper.resource_pools.store = _RaisingStore()
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        with self.assertRaises(JobNotReadyException):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), user, self._job(40))
+
+    def test_fail_open_pool_admits_when_store_unavailable(self):
+        mapper = self._mapper()
+        mapper.resource_pools.store = _RaisingStore()
+        # A non-security pool marked fail_open lets jobs through during a store outage.
+        mapper.pools["default"].fail_open = True
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), user, self._job(41))
+        self.assertEqual(dest.id, "local")
+
+    def test_anonymous_user_is_not_governed(self):
+        mapper = self._mapper()
+        # No user -> per-user pools do not apply; the job maps and nothing is recorded.
+        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), None, self._job(42))
+        self.assertEqual(dest.id, "local")
+
+    def test_pools_disabled_is_noop(self):
+        # A config without a resource_pool_store / pools leaves enforcement entirely off.
+        basic = os.path.join(os.path.dirname(__file__), "fixtures/mapping-basic.yml")
+        mapper = EntityToDestinationMapper(TPVConfigLoader.from_url_or_path(basic))
+        self.assertIsNone(mapper.resource_pools)
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("bwa"), user, self._job(43))
+        self.assertIsNotNone(dest.id)
+
+    def test_pools_without_store_is_rejected(self):
+        # Declaring pool policy but omitting the store wiring must fail loudly, not silently
+        # disable enforcement (fail-open by omission).
+        loader = TPVConfigLoader.from_url_or_path(FIXTURE)
+        loader.config.global_config.resource_pool_store = None
+        with self.assertRaisesRegex(ValueError, "resource_pool_store"):
+            EntityToDestinationMapper(loader)
+
 
 def _build_valkey_store():
     """A ValkeyAllocationStore backed by fakeredis, or None when fakeredis+Lua is unavailable.
@@ -369,8 +452,14 @@ PARITY_SCENARIOS = {
 
 class TestStoreParity(unittest.TestCase):
     def test_valkey_matches_in_memory(self):
-        if _build_valkey_store() is None:
-            self.skipTest("fakeredis with Lua support not available")
+        # fakeredis[lua] is a declared test dependency (see pyproject.toml). Fail hard if it is
+        # missing rather than skipping, so the production Lua admit path can never drift from
+        # _decide() unverified.
+        self.assertIsNotNone(
+            _build_valkey_store(),
+            "fakeredis[lua] is required to run the store parity contract (install the 'test' "
+            "extra); the Valkey Lua admit path must not go unverified.",
+        )
         for name, ops in PARITY_SCENARIOS.items():
             with self.subTest(scenario=name):
                 in_memory = InMemoryAllocationStore()

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -1,0 +1,389 @@
+import os
+import unittest
+
+from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
+
+from tpv.commands.test import mock_galaxy
+from tpv.core.loader import TPVConfigLoader
+from tpv.core.mapper import EntityToDestinationMapper
+from tpv.core.resource_pool import (
+    NORMAL,
+    OVERSIZE,
+    Budget,
+    ConfigBudgetProvider,
+    InMemoryAllocationStore,
+    ResourcePoolConfig,
+    ResourceUsage,
+    StoreUnavailable,
+    ValkeyAllocationStore,
+    terminal_job_ids,
+)
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "fixtures/mapping-resource-pool.yml")
+UNLIMITED = Budget()
+
+
+def _seed(store, pool, user_id, job_id, usage, kind=NORMAL):
+    """Force a ledger entry regardless of budget (used to simulate pre-existing jobs)."""
+    assert store.admit(
+        pool,
+        user_id,
+        job_id,
+        usage,
+        kind=kind,
+        budget=UNLIMITED,
+        max_oversize=10**9,
+        reserve_pool=False,
+        drop_job_ids=set(),
+    )
+
+
+class TestAllocationStore(unittest.TestCase):
+    def setUp(self):
+        self.store = InMemoryAllocationStore()
+        self.budget = Budget(cores=32, mem=256, gpus=2)
+
+    def test_admit_and_read(self):
+        ok = self.store.admit(
+            "default",
+            1,
+            100,
+            ResourceUsage(8, 16, 0),
+            kind=NORMAL,
+            budget=self.budget,
+            max_oversize=0,
+            reserve_pool=False,
+            drop_job_ids=set(),
+        )
+        self.assertTrue(ok)
+        ledger = self.store.read("default", 1)
+        self.assertEqual(ledger[100], (ResourceUsage(8, 16, 0), NORMAL))
+
+    def test_over_budget_defers(self):
+        _seed(self.store, "default", 1, 100, ResourceUsage(28, 16, 0))
+        # 28 + 8 = 36 > 32 cores
+        ok = self.store.admit(
+            "default",
+            1,
+            101,
+            ResourceUsage(8, 16, 0),
+            kind=NORMAL,
+            budget=self.budget,
+            max_oversize=0,
+            reserve_pool=False,
+            drop_job_ids=set(),
+        )
+        self.assertFalse(ok)
+        self.assertNotIn(101, self.store.read("default", 1))
+
+    def test_pool_separation_by_name_and_user(self):
+        _seed(self.store, "default", 1, 100, ResourceUsage(32, 0, 0))
+        # Same user, different pool -> independent ledger.
+        self.assertEqual(self.store.read("gpu", 1), {})
+        # Different user -> independent ledger.
+        self.assertEqual(self.store.read("default", 2), {})
+
+    def test_oversize_count_limit(self):
+        ok1 = self.store.admit(
+            "default",
+            1,
+            100,
+            ResourceUsage(64, 0, 0),
+            kind=OVERSIZE,
+            budget=self.budget,
+            max_oversize=1,
+            reserve_pool=False,
+            drop_job_ids=set(),
+        )
+        self.assertTrue(ok1)
+        ok2 = self.store.admit(
+            "default",
+            1,
+            101,
+            ResourceUsage(64, 0, 0),
+            kind=OVERSIZE,
+            budget=self.budget,
+            max_oversize=1,
+            reserve_pool=False,
+            drop_job_ids=set(),
+        )
+        self.assertFalse(ok2)
+
+    def test_reserve_pool_blocks_co_tenancy(self):
+        _seed(self.store, "default", 1, 100, ResourceUsage(64, 0, 0), kind=OVERSIZE)
+        # A normal job cannot run while an oversize job holds the reserved pool.
+        ok = self.store.admit(
+            "default",
+            1,
+            101,
+            ResourceUsage(1, 0, 0),
+            kind=NORMAL,
+            budget=self.budget,
+            max_oversize=1,
+            reserve_pool=True,
+            drop_job_ids=set(),
+        )
+        self.assertFalse(ok)
+
+    def test_drop_job_ids_releases_then_admits(self):
+        _seed(self.store, "default", 1, 100, ResourceUsage(30, 0, 0))
+        # Without dropping, this would not fit (30 + 8 > 32). Dropping 100 frees the pool.
+        ok = self.store.admit(
+            "default",
+            1,
+            101,
+            ResourceUsage(8, 0, 0),
+            kind=NORMAL,
+            budget=self.budget,
+            max_oversize=0,
+            reserve_pool=False,
+            drop_job_ids={100},
+        )
+        self.assertTrue(ok)
+        self.assertNotIn(100, self.store.read("default", 1))
+
+    def test_readmitting_same_job_does_not_double_count(self):
+        _seed(self.store, "default", 1, 100, ResourceUsage(30, 0, 0))
+        # Re-admitting job 100 (e.g. resubmission) replaces its entry rather than stacking.
+        ok = self.store.admit(
+            "default",
+            1,
+            100,
+            ResourceUsage(30, 0, 0),
+            kind=NORMAL,
+            budget=self.budget,
+            max_oversize=0,
+            reserve_pool=False,
+            drop_job_ids=set(),
+        )
+        self.assertTrue(ok)
+        self.assertEqual(len(self.store.read("default", 1)), 1)
+
+
+class TestBudgetProvider(unittest.TestCase):
+    def test_flat_per_pool_budget(self):
+        config = ResourcePoolConfig.model_validate(
+            {"pools": {"gpu": {"max_gpus": 2}, "cpu": {"max_cores": 16, "max_mem": 64}}}
+        )
+        provider = ConfigBudgetProvider(config)
+        self.assertEqual(provider.budget_for(None, "gpu"), Budget(cores=None, mem=None, gpus=2))
+        self.assertEqual(provider.budget_for(None, "cpu"), Budget(cores=16, mem=64, gpus=None))
+        self.assertEqual(provider.budget_for(None, "missing"), Budget())
+
+
+class TestTerminalJobIds(unittest.TestCase):
+    def test_returns_only_terminal_jobs(self):
+        app = mock_galaxy.App(create_model=True)
+        sa_session = app.model.context
+        user = app.model.User(username="trillian", email="trillian@vortex.org", password="x")
+        sa_session.add(user)
+        sa_session.flush()
+
+        def make_job(state):
+            job = app.model.Job()
+            job.user = user
+            job.tool_id = "t"
+            job.state = state
+            sa_session.add(job)
+            sa_session.flush()
+            return job.id
+
+        running = make_job("running")
+        done = make_job("ok")
+        errored = make_job("error")
+
+        self.assertEqual(terminal_job_ids(app.model.context, set()), set())
+        self.assertEqual(
+            terminal_job_ids(app.model.context, {running, done, errored}),
+            {done, errored},
+        )
+
+
+class TestResourcePoolMapping(unittest.TestCase):
+    def _mapper(self):
+        return EntityToDestinationMapper(TPVConfigLoader.from_url_or_path(FIXTURE))
+
+    @staticmethod
+    def _job(job_id):
+        job = mock_galaxy.Job()
+        job.id = job_id
+        return job
+
+    def _app(self):
+        return mock_galaxy.App(create_model=True)
+
+    def test_under_budget_maps(self):
+        mapper = self._mapper()
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), user, self._job(1))
+        self.assertEqual(dest.id, "local")
+        # The job was recorded against the pool.
+        self.assertIn(1, mapper.resource_pools.store.read("default", 1))
+
+    def test_over_budget_defers(self):
+        mapper = self._mapper()
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        _seed(mapper.resource_pools.store, "default", 1, 900, ResourceUsage(30, 0, 0))
+        with self.assertRaises(JobNotReadyException):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), user, self._job(1))
+
+    def test_per_user_isolation(self):
+        mapper = self._mapper()
+        arthur = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        ford = mock_galaxy.User("ford", "ford@vortex.org", id=2)
+        _seed(mapper.resource_pools.store, "default", arthur.id, 900, ResourceUsage(30, 0, 0))
+        with self.assertRaises(JobNotReadyException):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), arthur, self._job(1))
+        # ford is unaffected by arthur's full pool.
+        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), ford, self._job(2))
+        self.assertEqual(dest.id, "local")
+
+    def test_oversize_admitted_then_second_defers(self):
+        mapper = self._mapper()
+        user = mock_galaxy.User("zaphod", "zaphod@vortex.org", id=3)
+        # 64 cores > 32 budget -> oversize, allowed up to max_concurrent=1.
+        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("bigtool"), user, self._job(10))
+        self.assertEqual(dest.id, "local")
+        # A second oversize job exceeds max_concurrent=1 -> deferred.
+        with self.assertRaises(JobNotReadyException):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("bigtool"), user, self._job(11))
+
+    def test_oversize_beyond_hard_max_fails(self):
+        mapper = self._mapper()
+        user = mock_galaxy.User("zaphod", "zaphod@vortex.org", id=3)
+        with self.assertRaisesRegex(JobMappingException, "can never be scheduled"):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("hugetool"), user, self._job(12))
+
+    def test_udt_pool_without_oversize_fails(self):
+        mapper = self._mapper()
+        user = mock_galaxy.User("zaphod", "zaphod@vortex.org", id=3)
+        with self.assertRaisesRegex(JobMappingException, "can never be scheduled"):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("udt_tool"), user, self._job(13))
+
+    def test_reconciliation_releases_terminal_jobs(self):
+        mapper = self._mapper()
+        app = self._app()
+        sa_session = app.model.context
+        db_user = app.model.User(username="marvin", email="marvin@vortex.org", password="x")
+        sa_session.add(db_user)
+        sa_session.flush()
+        finished = app.model.Job()
+        finished.user = db_user
+        finished.tool_id = "default"
+        finished.state = "ok"
+        sa_session.add(finished)
+        sa_session.flush()
+
+        user = mock_galaxy.User("marvin", "marvin@vortex.org", id=db_user.id)
+        # The finished job's allocation lingers in the ledger and would otherwise fill the pool.
+        _seed(mapper.resource_pools.store, "default", user.id, finished.id, ResourceUsage(30, 0, 0))
+        # Mapping reconciles the terminal job out, freeing the pool for the new job.
+        dest = mapper.map_to_destination(app, mock_galaxy.Tool("default"), user, self._job(20))
+        self.assertEqual(dest.id, "local")
+        ledger = mapper.resource_pools.store.read("default", user.id)
+        self.assertNotIn(finished.id, ledger)
+        self.assertIn(20, ledger)
+
+    def test_oversize_beyond_hard_max_mem_fails(self):
+        # 600GB mem > hard_max_mem of 512 (cores fit) -> the memory ceiling is enforced too.
+        mapper = self._mapper()
+        user = mock_galaxy.User("zaphod", "zaphod@vortex.org", id=3)
+        with self.assertRaisesRegex(JobMappingException, "can never be scheduled"):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("bigmem_tool"), user, self._job(14))
+
+    def test_gpu_pool_admits_and_defers(self):
+        mapper = self._mapper()
+        user = mock_galaxy.User("zaphod", "zaphod@vortex.org", id=3)
+        # A GPU job within the 2-GPU budget maps and is recorded against the gpu pool.
+        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("gpu_tool"), user, self._job(15))
+        self.assertEqual(dest.id, "local")
+        self.assertEqual(mapper.resource_pools.store.read("gpu", user.id)[15][0].gpus, 1)
+
+    def test_gpu_pool_defers_when_full(self):
+        mapper = self._mapper()
+        user = mock_galaxy.User("zaphod", "zaphod@vortex.org", id=3)
+        # The user already holds both GPUs; a further GPU job is deferred even though its
+        # CPU/memory request would fit the default pool.
+        _seed(mapper.resource_pools.store, "gpu", user.id, 800, ResourceUsage(0, 0, 2))
+        with self.assertRaises(JobNotReadyException):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("gpu_tool"), user, self._job(16))
+
+
+def _build_valkey_store():
+    """A ValkeyAllocationStore backed by fakeredis, or None when fakeredis+Lua is unavailable.
+
+    Lets the parity test run the *real* Valkey adapter (Lua admit script, ``|`` serialisation,
+    URL handling) without a live server, falling back to skip when the dependency is absent.
+    """
+    try:
+        import fakeredis
+    except ImportError:
+        return None
+    try:
+        client = fakeredis.FakeStrictRedis(decode_responses=True)
+        return ValkeyAllocationStore(client=client)
+    except Exception:
+        return None
+
+
+def _op(job_id, req, *, kind=NORMAL, budget=Budget(32, 256, 2), max_oversize=0, reserve_pool=False, drop=()):
+    return dict(
+        pool="p",
+        user_id=1,
+        job_id=job_id,
+        req=req,
+        kind=kind,
+        budget=budget,
+        max_oversize=max_oversize,
+        reserve_pool=reserve_pool,
+        drop_job_ids=set(drop),
+    )
+
+
+# Each scenario is a sequence of admit() calls applied to a fresh store. The parity test asserts
+# the in-memory and Valkey/Lua implementations return identical decisions and leave identical
+# ledgers -- pinning the duplicated admission logic (Python _decide vs the _ADMIT_LUA script) to
+# one contract, and covering the cores/mem/gpus/unlimited dimensions.
+PARITY_SCENARIOS = {
+    "cores_over_budget": [_op(1, ResourceUsage(28, 0, 0)), _op(2, ResourceUsage(8, 0, 0))],
+    "mem_over_budget": [
+        _op(1, ResourceUsage(1, 10, 0), budget=Budget(100, 16, 2)),
+        _op(2, ResourceUsage(1, 10, 0), budget=Budget(100, 16, 2)),
+    ],
+    "gpu_over_budget": [_op(1, ResourceUsage(1, 0, 2)), _op(2, ResourceUsage(1, 0, 1))],
+    "unlimited_dimensions": [
+        _op(1, ResourceUsage(4, 9999, 9999), budget=Budget(4, None, None)),
+        _op(2, ResourceUsage(1, 0, 0), budget=Budget(4, None, None)),
+    ],
+    "oversize_count_limit": [
+        _op(1, ResourceUsage(64, 0, 0), kind=OVERSIZE, max_oversize=1),
+        _op(2, ResourceUsage(64, 0, 0), kind=OVERSIZE, max_oversize=1),
+    ],
+    "reserve_pool": [
+        _op(1, ResourceUsage(64, 0, 0), kind=OVERSIZE, max_oversize=1, reserve_pool=True),
+        _op(2, ResourceUsage(1, 0, 0), kind=NORMAL, max_oversize=1, reserve_pool=True),
+    ],
+    "drop_releases": [_op(1, ResourceUsage(30, 0, 0)), _op(2, ResourceUsage(8, 0, 0), drop=(1,))],
+}
+
+
+class TestStoreParity(unittest.TestCase):
+    def test_valkey_matches_in_memory(self):
+        if _build_valkey_store() is None:
+            self.skipTest("fakeredis with Lua support not available")
+        for name, ops in PARITY_SCENARIOS.items():
+            with self.subTest(scenario=name):
+                in_memory = InMemoryAllocationStore()
+                valkey = _build_valkey_store()
+                mem_results = [in_memory.admit(**op) for op in ops]
+                vk_results = [valkey.admit(**op) for op in ops]
+                self.assertEqual(mem_results, vk_results, f"admit decisions differ for {name}")
+                self.assertEqual(
+                    in_memory.read("p", 1),
+                    valkey.read("p", 1),
+                    f"final ledgers differ for {name}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -291,6 +291,29 @@ class TestResourcePoolMapping(unittest.TestCase):
     def _app(self):
         return mock_galaxy.App(create_model=True)
 
+    def test_abstract_pool_is_only_an_inheritance_template(self):
+        loader = TPVConfigLoader.from_url_or_path(FIXTURE)
+        loader.config.pools["template"] = PoolEntity(
+            id="template",
+            abstract=True,
+            max_concurrent_cores=1,
+            scheduling={"require": ["gpu"]},
+            evaluator=loader,
+        )
+        loader.config.pools["gpu"] = PoolEntity(
+            id="gpu",
+            inherits="template",
+            max_concurrent_cores=8,
+            evaluator=loader,
+        )
+        loader.process_entities(loader.config)
+        mapper = EntityToDestinationMapper(loader)
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("gpu_tool"), user, self._job(1))
+        self.assertEqual(dest.id, "local")
+        self.assertEqual(mapper.resource_pools.store.read("template", user.id), {})
+        self.assertIn(1, mapper.resource_pools.store.read("gpu", user.id))
+
     def test_under_budget_maps(self):
         mapper = self._mapper()
         user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
 
 from tpv.commands.test import mock_galaxy
+from tpv.core.entities import PoolEntity, SchedulingTags, Tool
 from tpv.core.loader import TPVConfigLoader
 from tpv.core.mapper import EntityToDestinationMapper
 from tpv.core.resource_pool import (
@@ -206,6 +207,21 @@ class TestTerminalJobIds(unittest.TestCase):
         )
 
 
+class TestPoolMembership(unittest.TestCase):
+    def test_untagged_pool_covers_required_routing_tags(self):
+        pool = PoolEntity()
+        self.assertTrue(pool.matches(Tool(scheduling={"require": ["gpu", "pulsar"]})))
+
+    def test_pool_selects_positive_job_tags_only(self):
+        pool = PoolEntity(scheduling={"require": ["gpu"], "reject": ["udt"]})
+        for tag_type in ("require", "prefer", "accept"):
+            with self.subTest(tag_type=tag_type):
+                self.assertTrue(pool.matches(Tool(scheduling={tag_type: ["gpu"], "reject": ["udt"]})))
+                self.assertFalse(pool.matches(Tool(scheduling={tag_type: ["gpu", "udt"]})))
+        self.assertFalse(pool.matches(Tool(scheduling={"reject": ["gpu"]})))
+        self.assertFalse(pool.matches(Tool()))
+
+
 class TestResourcePoolMapping(unittest.TestCase):
     def _mapper(self):
         return EntityToDestinationMapper(TPVConfigLoader.from_url_or_path(FIXTURE))
@@ -226,6 +242,15 @@ class TestResourcePoolMapping(unittest.TestCase):
         self.assertEqual(dest.id, "local")
         # The job was recorded against the pool.
         self.assertIn(1, mapper.resource_pools.store.read("default", 1))
+
+    def test_required_routing_tag_does_not_bypass_default_budget(self):
+        mapper = self._mapper()
+        mapper.config.tools["default"].tpv_tags = SchedulingTags(require=["gpu"])
+        mapper.destinations["local"].tpv_dest_tags = SchedulingTags(accept=["gpu"])
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        _seed(mapper.resource_pools.store, "default", user.id, 900, ResourceUsage(32, 0, 0))
+        with self.assertRaises(JobNotReadyException):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), user, self._job(1))
 
     def test_over_budget_defers(self):
         mapper = self._mapper()

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -593,7 +593,7 @@ def _build_valkey_store():
     """A ValkeyAllocationStore backed by fakeredis, or None when fakeredis+Lua is unavailable.
 
     Lets the parity test run the *real* Valkey adapter (Lua admit script, ``|`` serialisation,
-    URL handling) without a live server, falling back to skip when the dependency is absent.
+    URL handling) without a live server. The contract test fails if the dependency is absent.
     """
     try:
         import fakeredis

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -207,6 +207,62 @@ class TestTerminalJobIds(unittest.TestCase):
         )
 
 
+class TestPoolInheritance(unittest.TestCase):
+    def test_omitted_and_partial_policy_inherit_across_multiple_levels(self):
+        pools = TPVConfigLoader(
+            {
+                "pools": {
+                    "parent": {
+                        "fail_open": True,
+                        "max_concurrent_cores": 32,
+                        "oversize": {"max_concurrent": 1, "hard_max_cores": 128, "reserve_pool": True},
+                    },
+                    "child": {"inherits": "parent"},
+                    "grandchild": {"inherits": "child", "oversize": {"max_concurrent": 2}},
+                }
+            }
+        ).config.pools
+        self.assertEqual(pools["child"].oversize, pools["parent"].oversize)
+        self.assertTrue(pools["child"].fail_open)
+        self.assertEqual(pools["grandchild"].oversize.max_concurrent, 2)
+        self.assertEqual(pools["grandchild"].oversize.hard_max_cores, 128)
+        self.assertTrue(pools["grandchild"].oversize.reserve_pool)
+        self.assertEqual(pools["grandchild"].max_concurrent_cores, 32)
+        self.assertEqual(pools["parent"].oversize.max_concurrent, 1)
+
+    def test_explicit_false_zero_and_null_override_parent_policy(self):
+        pools = TPVConfigLoader(
+            {
+                "pools": {
+                    "parent": {
+                        "fail_open": True,
+                        "oversize": {"max_concurrent": 1, "hard_max_cores": 128, "reserve_pool": True},
+                    },
+                    "child": {
+                        "inherits": "parent",
+                        "fail_open": False,
+                        "oversize": {"max_concurrent": 0, "hard_max_cores": None, "reserve_pool": False},
+                    },
+                }
+            }
+        ).config.pools
+        self.assertFalse(pools["child"].fail_open)
+        self.assertEqual(pools["child"].oversize.max_concurrent, 0)
+        self.assertIsNone(pools["child"].oversize.hard_max_cores)
+        self.assertFalse(pools["child"].oversize.reserve_pool)
+
+    def test_overlay_config_preserves_unspecified_policy(self):
+        parent = TPVConfigLoader(
+            {"pools": {"p": {"fail_open": True, "oversize": {"max_concurrent": 1, "hard_max_mem": 512}}}}
+        )
+        child = TPVConfigLoader({"pools": {"p": {"oversize": {"hard_max_cores": 128}}}}, parent=parent)
+        pool = child.config.pools["p"]
+        self.assertTrue(pool.fail_open)
+        self.assertEqual(pool.oversize.max_concurrent, 1)
+        self.assertEqual(pool.oversize.hard_max_mem, 512)
+        self.assertEqual(pool.oversize.hard_max_cores, 128)
+
+
 class TestPoolMembership(unittest.TestCase):
     def test_untagged_pool_covers_required_routing_tags(self):
         pool = PoolEntity()

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -1,11 +1,13 @@
 import os
 import unittest
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from unittest.mock import patch
 
 from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
 
 from tpv.commands.test import mock_galaxy
-from tpv.core.entities import PoolEntity, SchedulingTags, Tool
+from tpv.core.entities import PoolEntity, Rule, SchedulingTags, Tool
 from tpv.core.loader import TPVConfigLoader
 from tpv.core.mapper import EntityToDestinationMapper
 from tpv.core.resource_pool import (
@@ -14,6 +16,7 @@ from tpv.core.resource_pool import (
     AllocationStore,
     Budget,
     InMemoryAllocationStore,
+    PoolAdmission,
     ResourceUsage,
     StoreUnavailable,
     ValkeyAllocationStore,
@@ -446,6 +449,52 @@ class TestResourcePoolMapping(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, f"scheduling.{kind}"):
                     PoolEntity.model_validate({"scheduling": {kind: ["gpu"]}})
 
+    def test_gpu_deferrals_leave_cpu_budget_available(self):
+        mapper = self._mapper()
+        app = self._app()
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        _seed(mapper.resource_pools.store, "gpu", user.id, 900, ResourceUsage(0, 0, 2))
+        for jid in range(1, 9):
+            with self.assertRaises(JobNotReadyException):
+                mapper.map_to_destination(app, mock_galaxy.Tool("gpu_tool"), user, self._job(jid))
+        self.assertEqual(mapper.resource_pools.store.read("default", user.id), {})
+        dest = mapper.map_to_destination(app, mock_galaxy.Tool("default"), user, self._job(10))
+        self.assertEqual(dest.id, "local")
+
+    def test_permanent_rejection_leaves_no_partial_allocations(self):
+        mapper = self._mapper()
+        mapper.pools["z_last"] = PoolEntity(max_concurrent_cores=1)
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        with self.assertRaisesRegex(JobMappingException, "can never be scheduled"):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), user, self._job(1))
+        self.assertEqual(mapper.resource_pools.store.read("default", user.id), {})
+
+    def test_destination_rejection_leaves_no_allocations(self):
+        for exception in ("TryNextDestinationOrWait", "TryNextDestinationOrFail"):
+            with self.subTest(exception=exception):
+                mapper = self._mapper()
+                mapper.destinations["local"].rules = {
+                    "reject": Rule(
+                        **{
+                            "if": True,
+                            "execute": f"from tpv.core.entities import {exception}\nraise {exception}()\nNone",
+                            "evaluator": mapper.loader,
+                        }
+                    )
+                }
+                user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+                with self.assertRaises((JobNotReadyException, JobMappingException)):
+                    mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), user, self._job(1))
+                self.assertEqual(mapper.resource_pools.store.read("default", user.id), {})
+
+    def test_destination_clamping_does_not_change_billed_request(self):
+        mapper = self._mapper()
+        mapper.destinations["local"].max_cores = 1
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), user, self._job(1))
+        self.assertEqual(dest.params["native_spec"], "--cores 1 --mem 2")
+        self.assertEqual(mapper.resource_pools.store.read("default", user.id)[1][0], ResourceUsage(4, 8, 0))
+
     def test_user_budget_override_wins_over_pool_default(self):
         # trillian's user entity raises max_concurrent_cores to 128; combine resolves it over the
         # default pool's 32, so two 64-core bigtool jobs are admitted as *normal* (not oversize).
@@ -464,7 +513,7 @@ class _RaisingStore(AllocationStore):
     def read(self, pool, user_id):
         raise StoreUnavailable("backend down")
 
-    def admit(self, *args, **kwargs):
+    def admit_many(self, *args, **kwargs):
         raise StoreUnavailable("backend down")
 
 
@@ -499,6 +548,22 @@ class TestResourcePoolBranches(unittest.TestCase):
         user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
         dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("default"), user, self._job(41))
         self.assertEqual(dest.id, "local")
+
+    def test_batch_write_failure_requires_every_pool_to_fail_open(self):
+        for strict in (True, False):
+            with self.subTest(strict=strict):
+                mapper = self._mapper()
+                mapper.pools["default"].fail_open = True
+                mapper.pools["gpu"].fail_open = not strict
+                user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+                with patch.object(mapper.resource_pools.store, "admit_many", side_effect=StoreUnavailable("down")):
+                    if strict:
+                        with self.assertRaises(JobNotReadyException):
+                            mapper.map_to_destination(self._app(), mock_galaxy.Tool("gpu_tool"), user, self._job(1))
+                    else:
+                        dest = mapper.map_to_destination(self._app(), mock_galaxy.Tool("gpu_tool"), user, self._job(1))
+                        self.assertEqual(dest.id, "local")
+                self.assertEqual(mapper.resource_pools.store.read("default", user.id), {})
 
     def test_anonymous_user_is_not_governed(self):
         mapper = self._mapper()
@@ -606,6 +671,65 @@ PARITY_SCENARIOS = {
     ],
     "drop_releases": [_op(1, ResourceUsage(30, 0, 0)), _op(2, ResourceUsage(8, 0, 0), drop=(1,))],
 }
+
+
+def _admission(pool, cores=4, *, drop=()):
+    return PoolAdmission(pool, ResourceUsage(cores, 0, 0), NORMAL, Budget(4, None, None), 0, False, set(drop))
+
+
+class TestAtomicPoolAdmission(unittest.TestCase):
+    def test_rejection_in_either_pool_is_atomic(self):
+        for build in (InMemoryAllocationStore, _build_valkey_store):
+            for full_pool in ("a", "b"):
+                with self.subTest(store=build.__name__, full_pool=full_pool):
+                    store = build()
+                    _seed(store, full_pool, 1, 99, ResourceUsage(4, 0, 0))
+                    self.assertFalse(store.admit_many(1, 1, [_admission("a"), _admission("b")]))
+                    for pool in ("a", "b"):
+                        self.assertNotIn(1, store.read(pool, 1))
+                    self.assertIn(99, store.read(full_pool, 1))
+
+    def test_rejected_retry_clears_old_entries_in_all_pools(self):
+        for build in (InMemoryAllocationStore, _build_valkey_store):
+            with self.subTest(store=build.__name__):
+                store = build()
+                for pool in ("a", "b"):
+                    _seed(store, pool, 1, 1, ResourceUsage(1, 0, 0))
+                _seed(store, "a", 1, 99, ResourceUsage(4, 0, 0))
+                self.assertFalse(store.admit_many(1, 1, [_admission("a"), _admission("b")]))
+                self.assertEqual(set(store.read("a", 1)), {99})
+                self.assertEqual(store.read("b", 1), {})
+                self.assertTrue(store.admit_many(1, 1, [_admission("a", drop={99}), _admission("b")]))
+                self.assertTrue(store.admit_many(1, 1, [_admission("a"), _admission("b")]))
+                for pool in ("a", "b"):
+                    self.assertEqual(store.read(pool, 1), {1: (ResourceUsage(4, 0, 0), NORMAL)})
+
+    def test_concurrent_jobs_cannot_oversubscribe_or_split_pools(self):
+        for build in (InMemoryAllocationStore, _build_valkey_store):
+            with self.subTest(store=build.__name__):
+                store = build()
+                # Warm up Lua loading before the racing admission calls.
+                _seed(store, "warmup", 1, 99, ResourceUsage())
+                barrier = Barrier(8)
+
+                def admit(jid):
+                    barrier.wait(timeout=10)
+                    return store.admit_many(1, jid, [_admission("a"), _admission("b")])
+
+                with ThreadPoolExecutor(max_workers=8) as executor:
+                    results = list(executor.map(admit, range(1, 9)))
+                self.assertEqual(sum(results), 1)
+                self.assertEqual(store.read("a", 1), store.read("b", 1))
+                self.assertEqual(len(store.read("a", 1)), 1)
+
+    def test_reconciliation_preserves_large_job_ids(self):
+        for build in (InMemoryAllocationStore, _build_valkey_store):
+            with self.subTest(store=build.__name__):
+                store = build()
+                job_id = 2**53 + 1
+                _seed(store, "a", 1, job_id, ResourceUsage(4, 0, 0))
+                self.assertTrue(store.admit_many(1, 1, [_admission("a", drop={job_id}), _admission("b")]))
+                self.assertNotIn(job_id, store.read("a", 1))
 
 
 class TestStoreParity(unittest.TestCase):

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import patch
 
 from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
 
@@ -434,6 +435,32 @@ def _build_valkey_store():
         return ValkeyAllocationStore(client=client)
     except Exception:
         return None
+
+
+class TestLedgerLifetime(unittest.TestCase):
+    def test_idle_ledger_keeps_running_allocation(self):
+        store = _build_valkey_store()
+        self.assertIsNotNone(store)
+        _seed(store, "p", 1, 1, ResourceUsage(32, 0, 0))
+        import time
+
+        with patch("time.time", return_value=time.time() + 7200):
+            self.assertIn(1, store.read("p", 1))
+            self.assertFalse(store.admit(**_op(2, ResourceUsage(1, 0, 0))))
+
+    def test_admission_removes_preexisting_key_expiry(self):
+        store = _build_valkey_store()
+        self.assertIsNotNone(store)
+        _seed(store, "p", 1, 1, ResourceUsage(32, 0, 0))
+        key = store._key("p", 1)
+        store.client.expire(key, 3600)
+        self.assertFalse(store.admit(**_op(2, ResourceUsage(1, 0, 0))))
+        self.assertEqual(store.client.ttl(key), -1)
+
+    def test_expiring_ledgers_are_rejected(self):
+        for ttl in (-1, 3600):
+            with self.subTest(ttl=ttl), self.assertRaisesRegex(ValueError, "cannot expire"):
+                ValkeyAllocationStore(ttl=ttl)
 
 
 def _op(job_id, req, *, kind=NORMAL, budget=Budget(32, 256, 2), max_oversize=0, reserve_pool=False, drop=()):

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -314,6 +314,33 @@ class TestResourcePoolMapping(unittest.TestCase):
         with self.assertRaises(JobNotReadyException):
             mapper.map_to_destination(self._app(), mock_galaxy.Tool("gpu_tool"), user, self._job(16))
 
+    def test_job_with_require_tags_is_still_governed_by_an_untagged_pool(self):
+        # A pool selects which jobs it governs; it does not negotiate capabilities with them.
+        # A job's own require tags describe what it needs from a *destination*, and must not
+        # exempt it from an untagged pool -- otherwise enforcement is silently bypassed.
+        mapper = self._mapper()
+        user = mock_galaxy.User("arthur", "arthur@vortex.org", id=1)
+        mapper.map_to_destination(self._app(), mock_galaxy.Tool("tagged_tool"), user, self._job(50))
+        self.assertIn(50, mapper.resource_pools.store.read("default", 1))
+
+    def test_pool_reject_tag_still_excludes_a_job(self):
+        # The 'default' pool rejects 'udt', so a udt job is governed only by the udt pool.
+        mapper = self._mapper()
+        user = mock_galaxy.User("zaphod", "zaphod@vortex.org", id=3)
+        with self.assertRaises(JobMappingException):
+            mapper.map_to_destination(self._app(), mock_galaxy.Tool("udt_tool"), user, self._job(51))
+        self.assertEqual(mapper.resource_pools.store.read("default", 3), {})
+
+    def test_prefer_and_accept_are_rejected_on_pools(self):
+        # Pools select jobs with require/reject only. prefer/accept have no meaning (there is no
+        # ranking among pools), so they must fail loudly at load rather than silently do nothing.
+        from tpv.core.entities import PoolEntity
+
+        for kind in ("prefer", "accept"):
+            with self.subTest(kind=kind):
+                with self.assertRaisesRegex(ValueError, f"scheduling.{kind}"):
+                    PoolEntity.model_validate({"scheduling": {kind: ["gpu"]}})
+
     def test_user_budget_override_wins_over_pool_default(self):
         # trillian's user entity raises max_concurrent_cores to 128; combine resolves it over the
         # default pool's 32, so two 64-core bigtool jobs are admitted as *normal* (not oversize).

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py3.13,lint,mypy
 
 [testenv]
 commands = # see setup.cfg for options sent to pytest and coverage
-    pytest -n logical --dist=loadgroup --cov=tpv --cov-branch -v {posargs}
+    pytest -n logical --dist=load --cov=tpv --cov-branch -v {posargs}
 setenv =
     # Fix for moto import issue: https://github.com/travis-ci/travis-ci/issues/7940
     BOTO_CONFIG=/dev/null

--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,13 @@ envlist = py3.13,lint,mypy
 
 [testenv]
 commands = # see setup.cfg for options sent to pytest and coverage
-    pytest -n logical --dist=load --cov=tpv --cov-branch -v {posargs}
+    pytest -n logical --dist=loadgroup --cov=tpv --cov-branch -v {posargs}
 setenv =
     # Fix for moto import issue: https://github.com/travis-ci/travis-ci/issues/7940
     BOTO_CONFIG=/dev/null
 passenv =
     PYTHONUNBUFFERED
+    TPV_TEST_REQUIRE_VALKEY
 deps =
     -rrequirements_test.txt
     pytest-cov

--- a/tpv/commands/dryrunner.py
+++ b/tpv/commands/dryrunner.py
@@ -3,6 +3,7 @@ import os
 from galaxy.jobs import JobDestination
 
 from tpv.core.explain import ExplainCollector
+from tpv.core.resource_pool import InMemoryAllocationStore
 from tpv.rules import gateway
 
 from .test import mock_galaxy
@@ -43,7 +44,17 @@ class TPVDryRunner:
         return resolved
 
     def run(self, explain: bool = False) -> tuple[JobDestination | None, ExplainCollector | None]:
-        gateway.ACTIVE_DESTINATION_MAPPERS = {}
+        # A dry run must never read from or write to the deployment's resource pool accounting:
+        # an admin checking a config change must not defer or admit real jobs, nor leave ledger
+        # entries behind. Build the mapper with a private in-memory store and pre-seed the
+        # gateway's registry so map_tool_to_destination uses it. (Deferral is a runtime question
+        # about live usage; a dry run answers the config questions: which pools govern the job,
+        # what budget applies, and whether the request is normal, oversize, or unschedulable.)
+        gateway.ACTIVE_DESTINATION_MAPPERS = {
+            "tpv_dispatcher": gateway.load_destination_mapper(
+                self.tpv_config_files, resource_pool_store=InMemoryAllocationStore()
+            )
+        }
         collector = ExplainCollector() if explain else None
         try:
             destination = gateway.map_tool_to_destination(

--- a/tpv/commands/dumper.py
+++ b/tpv/commands/dumper.py
@@ -53,6 +53,8 @@ class TPVConfigDumper:
         if config.roles:
             self._render_section(buf, "Roles", config.roles)
         self._render_section(buf, "Destinations", config.destinations)
+        if config.pools:
+            self._render_section(buf, "Pools", config.pools)
 
         buf.write("=" * 72 + "\n")
         return buf.getvalue()

--- a/tpv/commands/test/mock_galaxy.py
+++ b/tpv/commands/test/mock_galaxy.py
@@ -1,6 +1,6 @@
 import hashlib
 import itertools
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from galaxy.job_metrics import JobMetrics
 from galaxy.jobs import JobConfiguration
@@ -91,7 +91,14 @@ class JobToInputDatasetAssociation:
 
 
 class Job:
-    def __init__(self) -> None:
+    _next_id: ClassVar[int] = 1
+
+    def __init__(self, id: int | None = None) -> None:
+        # Resource pool admission keys a user's ledger by job id, so every job needs one.
+        if id is None:
+            id = Job._next_id
+            Job._next_id += 1
+        self.id = id
         self.input_datasets: list[JobToInputDatasetAssociation] = []
         self.input_library_datasets: list[JobToInputDatasetAssociation] = []
         self.param_values: dict[str, Any] = dict()

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -25,6 +25,7 @@ from typing_extensions import Self
 
 from .evaluator import TPVCodeEvaluator
 from .explain import ExplainCollector, ExplainPhase
+from .resource_pool import ResourcePoolConfig
 
 log = logging.getLogger(__name__)
 
@@ -722,6 +723,7 @@ class GlobalConfig(BaseModel):
 
     default_inherits: str | None = None
     context: dict[str, Any] = Field(default_factory=lambda: dict())
+    resource_pools: ResourcePoolConfig | None = None
 
 
 class TPVConfig(BaseModel):

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -25,7 +25,7 @@ from typing_extensions import Self
 
 from .evaluator import TPVCodeEvaluator
 from .explain import ExplainCollector, ExplainPhase
-from .resource_pool import ResourcePoolConfig
+from .resource_pool import Budget, OversizePolicy, StoreConfig
 
 log = logging.getLogger(__name__)
 
@@ -250,6 +250,12 @@ class Entity(BaseModel):
     max_cores: Annotated[int | float | str | None, TPVFieldMetadata()] = None
     max_mem: Annotated[int | float | str | None, TPVFieldMetadata()] = None
     max_gpus: Annotated[int | float | str | None, TPVFieldMetadata()] = None
+    # Per-user resource-pool budgets. Placed on the base entity so a Role/User can set them and
+    # the ordinary inherit+combine precedence (User > Role > Tool) resolves the effective budget;
+    # a PoolEntity supplies the default when no user/role overrides it. See PoolEntity.budget_for.
+    max_concurrent_cores: int | float | None = None
+    max_concurrent_mem: int | float | None = None
+    max_concurrent_gpus: int | float | None = None
     env: Annotated[list[dict[str, str]] | None, TPVFieldMetadata(complex_property=True)] = None
     params: Annotated[dict[str, Any] | None, TPVFieldMetadata(complex_property=True)] = None
     resubmit: Annotated[dict[str, dict[str, str | int | float | None]], TPVFieldMetadata(complex_property=True)] = (
@@ -349,7 +355,9 @@ class Entity(BaseModel):
         self.override_single_property(new_entity, self, entity, "max_cores")
         self.override_single_property(new_entity, self, entity, "max_mem")
         self.override_single_property(new_entity, self, entity, "max_gpus")
-        self.override_single_property(new_entity, self, entity, "max_gpus")
+        self.override_single_property(new_entity, self, entity, "max_concurrent_cores")
+        self.override_single_property(new_entity, self, entity, "max_concurrent_mem")
+        self.override_single_property(new_entity, self, entity, "max_concurrent_gpus")
         self.override_single_property(
             new_entity,
             self,
@@ -718,12 +726,67 @@ class Destination(EntityWithRules):
         return score
 
 
+class PoolEntity(EntityWithRules):
+    """A per-user resource pool as a first-class TPV entity.
+
+    A pool caps the aggregate ``max_concurrent_cores/mem/gpus`` a single user may hold across
+    their concurrently active jobs. It reuses the entity machinery for ``inherits:`` between
+    pools and scheduling tags (which job(s) a pool governs, matched like a Destination). Note
+    that pool ``rules`` are not evaluated during admission -- budgets are resolved from the
+    ``max_concurrent_*`` fields via ``combine`` precedence, not from rule expressions.
+
+    ``merge_order`` sits below Tool/Role/User so a User/Role that sets ``max_concurrent_*``
+    overrides the pool default through the ordinary combine precedence -- combine *is* the
+    budget provider, no bespoke provider needed. Selecting which pools govern a job is the same
+    tag match a Destination uses (``entity.tpv_tags.match(pool.tpv_dest_tags)``).
+    """
+
+    merge_order: ClassVar[int] = 1
+    oversize: OversizePolicy = OversizePolicy()
+    # What to do when the allocation store is down and we cannot check the user's usage.
+    # Default (False) = defer the job ("fail-closed": when unsure, say no). True = let it
+    # through ("fail-open": when unsure, allow), trading enforcement for availability. Keep it
+    # False for UDT/security pools where exceeding the limit is worse than waiting.
+    fail_open: bool = False
+    # Like Destination: tpv_tags is what a job requests, tpv_dest_tags is what this pool governs.
+    tpv_tags: SkipJsonSchema[SchedulingTags] = Field(exclude=True, default_factory=SchedulingTags)
+    tpv_dest_tags: SchedulingTags = Field(alias="scheduling", default_factory=SchedulingTags)
+
+    def override(self, entity: Self) -> Self:
+        new_entity = super().override(entity)
+        self.override_single_property(new_entity, self, entity, "oversize")
+        self.override_single_property(new_entity, self, entity, "fail_open")
+        return new_entity
+
+    def inherit(self, entity: Self) -> Self:
+        new_entity = super().inherit(entity)
+        if entity:
+            new_entity.tpv_dest_tags = self.tpv_dest_tags.inherit(entity.tpv_dest_tags)
+        return new_entity
+
+    def matches(self, entity: Entity) -> bool:
+        """Whether this pool governs ``entity``, using the same tag match as Destination."""
+        return entity.tpv_tags.match(self.tpv_dest_tags)
+
+    def budget_for(self, entity: Entity) -> Budget:
+        """Resolve the effective budget for ``entity``: a per-dimension value it carries (from a
+        User/Role override resolved by combine) wins, else this pool's default."""
+
+        def pick(dim: str) -> float | None:
+            override = getattr(entity, f"max_concurrent_{dim}", None)
+            value = override if override is not None else getattr(self, f"max_concurrent_{dim}")
+            return cast("float | None", value)
+
+        return Budget(cores=pick("cores"), mem=pick("mem"), gpus=pick("gpus"))
+
+
 class GlobalConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     default_inherits: str | None = None
     context: dict[str, Any] = Field(default_factory=lambda: dict())
-    resource_pools: ResourcePoolConfig | None = None
+    # Infrastructure wiring only (store class + options); pool policy lives in ``pools:``.
+    resource_pool_store: StoreConfig | None = None
 
 
 class TPVConfig(BaseModel):
@@ -735,6 +798,7 @@ class TPVConfig(BaseModel):
     users: dict[str, User] = Field(default_factory=lambda: dict())
     roles: dict[str, Role] = Field(default_factory=lambda: dict())
     destinations: dict[str, Destination] = Field(default_factory=lambda: dict())
+    pools: dict[str, PoolEntity] = Field(default_factory=lambda: dict())
 
     @model_validator(mode="after")
     def propagate_parent_properties(self) -> Self:
@@ -747,6 +811,8 @@ class TPVConfig(BaseModel):
                 role.propagate_parent_properties(id=id, evaluator=self.evaluator)
             for id, destination in self.destinations.items():
                 destination.propagate_parent_properties(id=id, evaluator=self.evaluator)
+            for id, pool in self.pools.items():
+                pool.propagate_parent_properties(id=id, evaluator=self.evaluator)
         return self
 
     @model_validator(mode="before")

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -764,9 +764,32 @@ class PoolEntity(EntityWithRules):
             new_entity.tpv_dest_tags = self.tpv_dest_tags.inherit(entity.tpv_dest_tags)
         return new_entity
 
+    @model_validator(mode="after")
+    def selector_tags_only(self) -> Self:
+        # A pool either governs a job or it does not; there is no ranking among pools, so
+        # prefer/accept cannot mean anything here. Fail at load rather than silently ignore them.
+        for kind in ("prefer", "accept"):
+            if getattr(self.tpv_dest_tags, kind):
+                raise ValueError(
+                    f"scheduling.{kind} has no meaning on a pool. A pool selects the jobs it "
+                    "governs with 'require' (job must carry all) and 'reject' (job must carry none)."
+                )
+        return self
+
     def matches(self, entity: Entity) -> bool:
-        """Whether this pool governs ``entity``, using the same tag match as Destination."""
-        return entity.tpv_tags.match(self.tpv_dest_tags)
+        """Whether this pool governs ``entity``.
+
+        Same vocabulary as a destination, but a pool never places demands back on the job. The
+        model to hold is *a destination that accepts every tag*: the job's own require/reject are
+        always satisfied, so only this pool's ``require`` (job must carry all) and ``reject`` (job
+        must carry none) decide. Using ``Destination``'s symmetric match here would exempt any job
+        carrying a ``require`` tag -- the norm for routing -- from an untagged pool, silently
+        bypassing enforcement.
+        """
+        job_tags = set(entity.tpv_tags.all_tag_values())
+        return set(self.tpv_dest_tags.require or []) <= job_tags and not (
+            set(self.tpv_dest_tags.reject or []) & job_tags
+        )
 
     def budget_for(self, entity: Entity) -> Budget:
         """Resolve the effective budget for ``entity``: a per-dimension value it carries (from a

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -779,6 +779,8 @@ class PoolEntity(EntityWithRules):
 
     def matches(self, entity: Entity) -> bool:
         """Select jobs by positive tags, independently of destination requirements."""
+        if self.abstract:
+            return False
         job_tags = (
             set(entity.tpv_tags.require or []) | set(entity.tpv_tags.prefer or []) | set(entity.tpv_tags.accept or [])
         )

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -731,14 +731,14 @@ class PoolEntity(EntityWithRules):
 
     A pool caps the aggregate ``max_concurrent_cores/mem/gpus`` a single user may hold across
     their concurrently active jobs. It reuses the entity machinery for ``inherits:`` between
-    pools and scheduling tags (which job(s) a pool governs, matched like a Destination). Note
+    pools and scheduling tags (which jobs a pool governs). Note
     that pool ``rules`` are not evaluated during admission -- budgets are resolved from the
     ``max_concurrent_*`` fields via ``combine`` precedence, not from rule expressions.
 
     ``merge_order`` sits below Tool/Role/User so a User/Role that sets ``max_concurrent_*``
     overrides the pool default through the ordinary combine precedence -- combine *is* the
-    budget provider, no bespoke provider needed. Selecting which pools govern a job is the same
-    tag match a Destination uses (``entity.tpv_tags.match(pool.tpv_dest_tags)``).
+    budget provider, no bespoke provider needed. Pool require/reject tags select jobs;
+    the job's required routing tags do not need to be supported by the pool.
     """
 
     merge_order: ClassVar[int] = 1
@@ -777,19 +777,13 @@ class PoolEntity(EntityWithRules):
         return self
 
     def matches(self, entity: Entity) -> bool:
-        """Whether this pool governs ``entity``.
-
-        Same vocabulary as a destination, but a pool never places demands back on the job. The
-        model to hold is *a destination that accepts every tag*: the job's own require/reject are
-        always satisfied, so only this pool's ``require`` (job must carry all) and ``reject`` (job
-        must carry none) decide. Using ``Destination``'s symmetric match here would exempt any job
-        carrying a ``require`` tag -- the norm for routing -- from an untagged pool, silently
-        bypassing enforcement.
-        """
-        job_tags = set(entity.tpv_tags.all_tag_values())
-        return set(self.tpv_dest_tags.require or []) <= job_tags and not (
-            set(self.tpv_dest_tags.reject or []) & job_tags
+        """Select jobs by positive tags, independently of destination requirements."""
+        job_tags = (
+            set(entity.tpv_tags.require or []) | set(entity.tpv_tags.prefer or []) | set(entity.tpv_tags.accept or [])
         )
+        return set(self.tpv_dest_tags.require or []).issubset(job_tags) and not set(
+            self.tpv_dest_tags.reject or []
+        ).intersection(job_tags)
 
     def budget_for(self, entity: Entity) -> Budget:
         """Resolve the effective budget for ``entity``: a per-dimension value it carries (from a

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -754,8 +754,9 @@ class PoolEntity(EntityWithRules):
 
     def override(self, entity: Self) -> Self:
         new_entity = super().override(entity)
-        self.override_single_property(new_entity, self, entity, "oversize")
-        self.override_single_property(new_entity, self, entity, "fail_open")
+        # Defaults are not overrides: inherit omitted policy fields, including ceilings.
+        new_entity.oversize = entity.oversize.model_copy(update=self.oversize.model_dump(exclude_unset=True))
+        new_entity.fail_open = self.fail_open if "fail_open" in self.model_fields_set else entity.fail_open
         return new_entity
 
     def inherit(self, entity: Self) -> Self:

--- a/tpv/core/explain.py
+++ b/tpv/core/explain.py
@@ -20,6 +20,7 @@ class ExplainPhase(Enum):
     DESTINATION_MATCHING = "Destination Matching"
     DESTINATION_RANKING = "Destination Ranking"
     DESTINATION_EVALUATION = "Destination Evaluation"
+    RESOURCE_POOLS = "Resource Pools"
     FINAL_RESULT = "Final Result"
 
 

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -180,6 +180,7 @@ def get_dataset_attributes(
             "size": get_dataset_size(i.dataset.dataset),
         }
         for i in datasets or {}
+        if i.dataset
     }
 
 

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -5,6 +5,8 @@ except ImportError:
     # If Galaxy is < 23.1 you need to have `packaging` in <= 21.3
     from packaging.version import parse as parse_version
 
+import copy
+import logging
 import operator
 import random
 from collections.abc import Callable
@@ -13,12 +15,23 @@ from typing import Any
 
 from galaxy import model
 from galaxy.app import UniverseApplication
+from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
 from galaxy.model import Dataset, Job, JobToInputDatasetAssociation
 from galaxy.model import User as GalaxyUser
 from galaxy.tools import Tool as GalaxyTool
 
 from tpv.core.entities import Destination, Entity
+from tpv.core.resource_pool import (
+    NORMAL,
+    OVERSIZE,
+    Budget,
+    ResourceUsage,
+    StoreUnavailable,
+    terminal_job_ids,
+)
 from tpv.core.resource_requirements import TPVResourceFieldName, extract_resource_requirements_from_tool
+
+log = logging.getLogger(__name__)
 
 GIGABYTES = 1024.0**3
 
@@ -168,3 +181,101 @@ def get_dataset_attributes(
         }
         for i in datasets or {}
     }
+
+
+def _evaluate_request(entity: Entity, context: dict[str, Any]) -> ResourceUsage:
+    # Resolve the entity's (possibly symbolic) cores/mem/gpus to clamped numbers. Pool rules
+    # run during rule evaluation, before resources are finalised, so e.g. ``mem: cores * 3``
+    # is still a string here. Use a shallow copy of the context so we don't pollute the live
+    # evaluation (evaluate_resources sets cores/mem/gpus keys on the context it is given).
+    evaluated = entity.evaluate_resources(copy.copy(context))
+    return ResourceUsage(
+        cores=float(evaluated.cores or 0),
+        mem=float(evaluated.mem or 0),
+        gpus=float(evaluated.gpus or 0),
+    )
+
+
+def _exceeds_budget(req: ResourceUsage, budget: Budget) -> bool:
+    return (
+        (budget.cores is not None and req.cores > budget.cores)
+        or (budget.mem is not None and req.mem > budget.mem)
+        or (budget.gpus is not None and req.gpus > budget.gpus)
+    )
+
+
+def enforce_resource_pool(context: dict[str, Any], name: str = "default") -> None:
+    """Enforce a per-user resource pool for the job currently being mapped.
+
+    Call this from a TPV rule's ``execute`` block, passing the evaluation ``context``::
+
+        rules:
+          - id: enforce_default_pool
+            if: entity.cores or entity.mem or entity.gpus
+            execute: |
+              helpers.enforce_resource_pool(context, name="default")
+
+    The user's aggregate allocation across their active jobs is tracked in the configured
+    allocation store (see ``global.resource_pools``). If admitting this job would exceed the
+    pool budget the job is deferred (``JobNotReadyException``); if the job is *oversize* (its
+    own request exceeds the budget) it is admitted only up to ``oversize.max_concurrent`` and
+    otherwise deferred, or failed (``JobMappingException``) when oversize jobs are not allowed
+    or the request is beyond the ``hard_max_*`` ceiling. If the store is unreachable the job
+    is deferred (fail-closed), never silently admitted.
+    """
+    mapper = context["mapper"]
+    manager = getattr(mapper, "resource_pools", None)
+    if manager is None:
+        return  # resource pools not configured for this deployment; no-op
+    pool = manager.pool(name)
+    if pool is None:
+        raise JobMappingException(  # type: ignore[no-untyped-call]
+            f"Resource pool '{name}' is not defined in the TPV configuration"
+        )
+
+    user = context.get("user")
+    if user is None:
+        return  # anonymous jobs are not governed by per-user pools
+
+    app = context["app"]
+    job = context["job"]
+    entity = context["entity"]
+
+    budget = manager.provider.budget_for(user, name)
+    req = _evaluate_request(entity, context)
+
+    is_oversize = _exceeds_budget(req, budget)
+    if is_oversize:
+        ceiling = Budget(
+            cores=pool.oversize.hard_max_cores,
+            mem=pool.oversize.hard_max_mem,
+            gpus=pool.oversize.hard_max_gpus,
+        )
+        if pool.oversize.max_concurrent <= 0 or _exceeds_budget(req, ceiling):
+            raise JobMappingException(  # type: ignore[no-untyped-call]
+                f"This job requests cores={req.cores}, mem={req.mem}, gpus={req.gpus}, which "
+                f"exceeds your '{name}' resource pool allocation and can never be scheduled."
+            )
+    kind = OVERSIZE if is_oversize else NORMAL
+
+    store = manager.store
+    try:
+        ledger_ids = set(store.read(name, user.id).keys())
+        drop = terminal_job_ids(app.model.context, ledger_ids)
+        admitted = store.admit(
+            name,
+            user.id,
+            job.id,
+            req,
+            kind=kind,
+            budget=budget,
+            max_oversize=pool.oversize.max_concurrent,
+            reserve_pool=pool.oversize.reserve_pool,
+            drop_job_ids=drop,
+        )
+    except StoreUnavailable:
+        log.warning("Resource pool '%s' store is unavailable; deferring job (fail-closed)", name)
+        raise JobNotReadyException()  # type: ignore[no-untyped-call]
+
+    if not admitted:
+        raise JobNotReadyException()  # type: ignore[no-untyped-call]

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -5,7 +5,6 @@ except ImportError:
     # If Galaxy is < 23.1 you need to have `packaging` in <= 21.3
     from packaging.version import parse as parse_version
 
-import copy
 import logging
 import operator
 import random
@@ -15,20 +14,11 @@ from typing import Any
 
 from galaxy import model
 from galaxy.app import UniverseApplication
-from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
 from galaxy.model import Dataset, Job, JobToInputDatasetAssociation
 from galaxy.model import User as GalaxyUser
 from galaxy.tools import Tool as GalaxyTool
 
 from tpv.core.entities import Destination, Entity
-from tpv.core.resource_pool import (
-    NORMAL,
-    OVERSIZE,
-    Budget,
-    ResourceUsage,
-    StoreUnavailable,
-    terminal_job_ids,
-)
 from tpv.core.resource_requirements import TPVResourceFieldName, extract_resource_requirements_from_tool
 
 log = logging.getLogger(__name__)
@@ -182,101 +172,3 @@ def get_dataset_attributes(
         for i in datasets or {}
         if i.dataset
     }
-
-
-def _evaluate_request(entity: Entity, context: dict[str, Any]) -> ResourceUsage:
-    # Resolve the entity's (possibly symbolic) cores/mem/gpus to clamped numbers. Pool rules
-    # run during rule evaluation, before resources are finalised, so e.g. ``mem: cores * 3``
-    # is still a string here. Use a shallow copy of the context so we don't pollute the live
-    # evaluation (evaluate_resources sets cores/mem/gpus keys on the context it is given).
-    evaluated = entity.evaluate_resources(copy.copy(context))
-    return ResourceUsage(
-        cores=float(evaluated.cores or 0),
-        mem=float(evaluated.mem or 0),
-        gpus=float(evaluated.gpus or 0),
-    )
-
-
-def _exceeds_budget(req: ResourceUsage, budget: Budget) -> bool:
-    return (
-        (budget.cores is not None and req.cores > budget.cores)
-        or (budget.mem is not None and req.mem > budget.mem)
-        or (budget.gpus is not None and req.gpus > budget.gpus)
-    )
-
-
-def enforce_resource_pool(context: dict[str, Any], name: str = "default") -> None:
-    """Enforce a per-user resource pool for the job currently being mapped.
-
-    Call this from a TPV rule's ``execute`` block, passing the evaluation ``context``::
-
-        rules:
-          - id: enforce_default_pool
-            if: entity.cores or entity.mem or entity.gpus
-            execute: |
-              helpers.enforce_resource_pool(context, name="default")
-
-    The user's aggregate allocation across their active jobs is tracked in the configured
-    allocation store (see ``global.resource_pools``). If admitting this job would exceed the
-    pool budget the job is deferred (``JobNotReadyException``); if the job is *oversize* (its
-    own request exceeds the budget) it is admitted only up to ``oversize.max_concurrent`` and
-    otherwise deferred, or failed (``JobMappingException``) when oversize jobs are not allowed
-    or the request is beyond the ``hard_max_*`` ceiling. If the store is unreachable the job
-    is deferred (fail-closed), never silently admitted.
-    """
-    mapper = context["mapper"]
-    manager = getattr(mapper, "resource_pools", None)
-    if manager is None:
-        return  # resource pools not configured for this deployment; no-op
-    pool = manager.pool(name)
-    if pool is None:
-        raise JobMappingException(  # type: ignore[no-untyped-call]
-            f"Resource pool '{name}' is not defined in the TPV configuration"
-        )
-
-    user = context.get("user")
-    if user is None:
-        return  # anonymous jobs are not governed by per-user pools
-
-    app = context["app"]
-    job = context["job"]
-    entity = context["entity"]
-
-    budget = manager.provider.budget_for(user, name)
-    req = _evaluate_request(entity, context)
-
-    is_oversize = _exceeds_budget(req, budget)
-    if is_oversize:
-        ceiling = Budget(
-            cores=pool.oversize.hard_max_cores,
-            mem=pool.oversize.hard_max_mem,
-            gpus=pool.oversize.hard_max_gpus,
-        )
-        if pool.oversize.max_concurrent <= 0 or _exceeds_budget(req, ceiling):
-            raise JobMappingException(  # type: ignore[no-untyped-call]
-                f"This job requests cores={req.cores}, mem={req.mem}, gpus={req.gpus}, which "
-                f"exceeds your '{name}' resource pool allocation and can never be scheduled."
-            )
-    kind = OVERSIZE if is_oversize else NORMAL
-
-    store = manager.store
-    try:
-        ledger_ids = set(store.read(name, user.id).keys())
-        drop = terminal_job_ids(app.model.context, ledger_ids)
-        admitted = store.admit(
-            name,
-            user.id,
-            job.id,
-            req,
-            kind=kind,
-            budget=budget,
-            max_oversize=pool.oversize.max_concurrent,
-            reserve_pool=pool.oversize.reserve_pool,
-            drop_job_ids=drop,
-        )
-    except StoreUnavailable:
-        log.warning("Resource pool '%s' store is unavailable; deferring job (fail-closed)", name)
-        raise JobNotReadyException()  # type: ignore[no-untyped-call]
-
-    if not admitted:
-        raise JobNotReadyException()  # type: ignore[no-untyped-call]

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -5,7 +5,6 @@ except ImportError:
     # If Galaxy is < 23.1 you need to have `packaging` in <= 21.3
     from packaging.version import parse as parse_version
 
-import copy
 import logging
 import operator
 import random
@@ -19,20 +18,11 @@ WeightedT = TypeVar("WeightedT", bound=Mapping[str, Any])
 
 from galaxy import model
 from galaxy.app import UniverseApplication
-from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
 from galaxy.model import Dataset, HistoryDatasetAssociation, Job, JobToInputDatasetAssociation
 from galaxy.model import User as GalaxyUser
 from galaxy.tools import Tool as GalaxyTool
 
 from tpv.core.entities import Destination, Entity
-from tpv.core.resource_pool import (
-    NORMAL,
-    OVERSIZE,
-    Budget,
-    ResourceUsage,
-    StoreUnavailable,
-    terminal_job_ids,
-)
 from tpv.core.resource_requirements import TPVResourceFieldName, extract_resource_requirements_from_tool
 
 log = logging.getLogger(__name__)
@@ -288,101 +278,3 @@ def get_dataset_attributes(
         for i in datasets or {}
         if i.dataset and i.dataset.dataset
     }
-
-
-def _evaluate_request(entity: Entity, context: dict[str, Any]) -> ResourceUsage:
-    # Resolve the entity's (possibly symbolic) cores/mem/gpus to clamped numbers. Pool rules
-    # run during rule evaluation, before resources are finalised, so e.g. ``mem: cores * 3``
-    # is still a string here. Use a shallow copy of the context so we don't pollute the live
-    # evaluation (evaluate_resources sets cores/mem/gpus keys on the context it is given).
-    evaluated = entity.evaluate_resources(copy.copy(context))
-    return ResourceUsage(
-        cores=float(evaluated.cores or 0),
-        mem=float(evaluated.mem or 0),
-        gpus=float(evaluated.gpus or 0),
-    )
-
-
-def _exceeds_budget(req: ResourceUsage, budget: Budget) -> bool:
-    return (
-        (budget.cores is not None and req.cores > budget.cores)
-        or (budget.mem is not None and req.mem > budget.mem)
-        or (budget.gpus is not None and req.gpus > budget.gpus)
-    )
-
-
-def enforce_resource_pool(context: dict[str, Any], name: str = "default") -> None:
-    """Enforce a per-user resource pool for the job currently being mapped.
-
-    Call this from a TPV rule's ``execute`` block, passing the evaluation ``context``::
-
-        rules:
-          - id: enforce_default_pool
-            if: entity.cores or entity.mem or entity.gpus
-            execute: |
-              helpers.enforce_resource_pool(context, name="default")
-
-    The user's aggregate allocation across their active jobs is tracked in the configured
-    allocation store (see ``global.resource_pools``). If admitting this job would exceed the
-    pool budget the job is deferred (``JobNotReadyException``); if the job is *oversize* (its
-    own request exceeds the budget) it is admitted only up to ``oversize.max_concurrent`` and
-    otherwise deferred, or failed (``JobMappingException``) when oversize jobs are not allowed
-    or the request is beyond the ``hard_max_*`` ceiling. If the store is unreachable the job
-    is deferred (fail-closed), never silently admitted.
-    """
-    mapper = context["mapper"]
-    manager = getattr(mapper, "resource_pools", None)
-    if manager is None:
-        return  # resource pools not configured for this deployment; no-op
-    pool = manager.pool(name)
-    if pool is None:
-        raise JobMappingException(  # type: ignore[no-untyped-call]
-            f"Resource pool '{name}' is not defined in the TPV configuration"
-        )
-
-    user = context.get("user")
-    if user is None:
-        return  # anonymous jobs are not governed by per-user pools
-
-    app = context["app"]
-    job = context["job"]
-    entity = context["entity"]
-
-    budget = manager.provider.budget_for(user, name)
-    req = _evaluate_request(entity, context)
-
-    is_oversize = _exceeds_budget(req, budget)
-    if is_oversize:
-        ceiling = Budget(
-            cores=pool.oversize.hard_max_cores,
-            mem=pool.oversize.hard_max_mem,
-            gpus=pool.oversize.hard_max_gpus,
-        )
-        if pool.oversize.max_concurrent <= 0 or _exceeds_budget(req, ceiling):
-            raise JobMappingException(  # type: ignore[no-untyped-call]
-                f"This job requests cores={req.cores}, mem={req.mem}, gpus={req.gpus}, which "
-                f"exceeds your '{name}' resource pool allocation and can never be scheduled."
-            )
-    kind = OVERSIZE if is_oversize else NORMAL
-
-    store = manager.store
-    try:
-        ledger_ids = set(store.read(name, user.id).keys())
-        drop = terminal_job_ids(app.model.context, ledger_ids)
-        admitted = store.admit(
-            name,
-            user.id,
-            job.id,
-            req,
-            kind=kind,
-            budget=budget,
-            max_oversize=pool.oversize.max_concurrent,
-            reserve_pool=pool.oversize.reserve_pool,
-            drop_job_ids=drop,
-        )
-    except StoreUnavailable:
-        log.warning("Resource pool '%s' store is unavailable; deferring job (fail-closed)", name)
-        raise JobNotReadyException()  # type: ignore[no-untyped-call]
-
-    if not admitted:
-        raise JobNotReadyException()  # type: ignore[no-untyped-call]

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -5,6 +5,8 @@ except ImportError:
     # If Galaxy is < 23.1 you need to have `packaging` in <= 21.3
     from packaging.version import parse as parse_version
 
+import copy
+import logging
 import operator
 import random
 import re
@@ -17,12 +19,23 @@ WeightedT = TypeVar("WeightedT", bound=Mapping[str, Any])
 
 from galaxy import model
 from galaxy.app import UniverseApplication
+from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
 from galaxy.model import Dataset, HistoryDatasetAssociation, Job, JobToInputDatasetAssociation
 from galaxy.model import User as GalaxyUser
 from galaxy.tools import Tool as GalaxyTool
 
 from tpv.core.entities import Destination, Entity
+from tpv.core.resource_pool import (
+    NORMAL,
+    OVERSIZE,
+    Budget,
+    ResourceUsage,
+    StoreUnavailable,
+    terminal_job_ids,
+)
 from tpv.core.resource_requirements import TPVResourceFieldName, extract_resource_requirements_from_tool
+
+log = logging.getLogger(__name__)
 
 # Bytes per GiB; retain the historical name for existing TPV rules.
 GIGABYTES = 1024.0**3
@@ -275,3 +288,101 @@ def get_dataset_attributes(
         for i in datasets or {}
         if i.dataset and i.dataset.dataset
     }
+
+
+def _evaluate_request(entity: Entity, context: dict[str, Any]) -> ResourceUsage:
+    # Resolve the entity's (possibly symbolic) cores/mem/gpus to clamped numbers. Pool rules
+    # run during rule evaluation, before resources are finalised, so e.g. ``mem: cores * 3``
+    # is still a string here. Use a shallow copy of the context so we don't pollute the live
+    # evaluation (evaluate_resources sets cores/mem/gpus keys on the context it is given).
+    evaluated = entity.evaluate_resources(copy.copy(context))
+    return ResourceUsage(
+        cores=float(evaluated.cores or 0),
+        mem=float(evaluated.mem or 0),
+        gpus=float(evaluated.gpus or 0),
+    )
+
+
+def _exceeds_budget(req: ResourceUsage, budget: Budget) -> bool:
+    return (
+        (budget.cores is not None and req.cores > budget.cores)
+        or (budget.mem is not None and req.mem > budget.mem)
+        or (budget.gpus is not None and req.gpus > budget.gpus)
+    )
+
+
+def enforce_resource_pool(context: dict[str, Any], name: str = "default") -> None:
+    """Enforce a per-user resource pool for the job currently being mapped.
+
+    Call this from a TPV rule's ``execute`` block, passing the evaluation ``context``::
+
+        rules:
+          - id: enforce_default_pool
+            if: entity.cores or entity.mem or entity.gpus
+            execute: |
+              helpers.enforce_resource_pool(context, name="default")
+
+    The user's aggregate allocation across their active jobs is tracked in the configured
+    allocation store (see ``global.resource_pools``). If admitting this job would exceed the
+    pool budget the job is deferred (``JobNotReadyException``); if the job is *oversize* (its
+    own request exceeds the budget) it is admitted only up to ``oversize.max_concurrent`` and
+    otherwise deferred, or failed (``JobMappingException``) when oversize jobs are not allowed
+    or the request is beyond the ``hard_max_*`` ceiling. If the store is unreachable the job
+    is deferred (fail-closed), never silently admitted.
+    """
+    mapper = context["mapper"]
+    manager = getattr(mapper, "resource_pools", None)
+    if manager is None:
+        return  # resource pools not configured for this deployment; no-op
+    pool = manager.pool(name)
+    if pool is None:
+        raise JobMappingException(  # type: ignore[no-untyped-call]
+            f"Resource pool '{name}' is not defined in the TPV configuration"
+        )
+
+    user = context.get("user")
+    if user is None:
+        return  # anonymous jobs are not governed by per-user pools
+
+    app = context["app"]
+    job = context["job"]
+    entity = context["entity"]
+
+    budget = manager.provider.budget_for(user, name)
+    req = _evaluate_request(entity, context)
+
+    is_oversize = _exceeds_budget(req, budget)
+    if is_oversize:
+        ceiling = Budget(
+            cores=pool.oversize.hard_max_cores,
+            mem=pool.oversize.hard_max_mem,
+            gpus=pool.oversize.hard_max_gpus,
+        )
+        if pool.oversize.max_concurrent <= 0 or _exceeds_budget(req, ceiling):
+            raise JobMappingException(  # type: ignore[no-untyped-call]
+                f"This job requests cores={req.cores}, mem={req.mem}, gpus={req.gpus}, which "
+                f"exceeds your '{name}' resource pool allocation and can never be scheduled."
+            )
+    kind = OVERSIZE if is_oversize else NORMAL
+
+    store = manager.store
+    try:
+        ledger_ids = set(store.read(name, user.id).keys())
+        drop = terminal_job_ids(app.model.context, ledger_ids)
+        admitted = store.admit(
+            name,
+            user.id,
+            job.id,
+            req,
+            kind=kind,
+            budget=budget,
+            max_oversize=pool.oversize.max_concurrent,
+            reserve_pool=pool.oversize.reserve_pool,
+            drop_job_ids=drop,
+        )
+    except StoreUnavailable:
+        log.warning("Resource pool '%s' store is unavailable; deferring job (fail-closed)", name)
+        raise JobNotReadyException()  # type: ignore[no-untyped-call]
+
+    if not admitted:
+        raise JobNotReadyException()  # type: ignore[no-untyped-call]

--- a/tpv/core/loader.py
+++ b/tpv/core/loader.py
@@ -112,6 +112,7 @@ class TPVConfigLoader(TPVCodeEvaluator):
         self.recompute_inheritance(tpv_config.users)
         self.recompute_inheritance(tpv_config.roles)
         self.recompute_inheritance(tpv_config.destinations)
+        self.recompute_inheritance(tpv_config.pools)
 
     def inherit_globals(self, parent_globals: GlobalConfig) -> None:
         if parent_globals:
@@ -121,6 +122,9 @@ class TPVConfigLoader(TPVCodeEvaluator):
             merged_context = dict(parent_globals.context or {})
             merged_context.update(self.config.global_config.context)
             self.config.global_config.context = merged_context
+            self.config.global_config.resource_pool_store = (
+                self.config.global_config.resource_pool_store or parent_globals.resource_pool_store
+            )
 
     def inherit_parent_entities(
         self,
@@ -161,6 +165,7 @@ class TPVConfigLoader(TPVCodeEvaluator):
         self.config.users = self.inherit_parent_entities(parent_config.users, self.config.users)
         self.config.roles = self.inherit_parent_entities(parent_config.roles, self.config.roles)
         self.config.destinations = self.inherit_parent_entities(parent_config.destinations, self.config.destinations)
+        self.config.pools = self.inherit_parent_entities(parent_config.pools, self.config.pools)
 
     @staticmethod
     def from_url_or_path(url_or_path: str, parent: TPVConfigLoader | None = None) -> TPVConfigLoader:

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import logging
 import re
@@ -7,7 +8,7 @@ from typing import Any, TypeVar, cast
 from cachetools import Cache, cached
 from galaxy.app import UniverseApplication
 from galaxy.jobs import JobDestination, JobWrapper
-from galaxy.jobs.mapper import JobNotReadyException
+from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
 from galaxy.model import Job
 from galaxy.model import User as GalaxyUser
 from galaxy.tools import Tool as GalaxyTool
@@ -16,6 +17,7 @@ from .entities import (
     Destination,
     Entity,
     EntityWithRules,
+    PoolEntity,
     Role,
     SchedulingTags,
     Tool,
@@ -25,7 +27,15 @@ from .entities import (
 )
 from .explain import ExplainCollector, ExplainPhase
 from .loader import TPVConfigLoader
-from .resource_pool import ResourcePoolManager
+from .resource_pool import (
+    NORMAL,
+    OVERSIZE,
+    Budget,
+    ResourcePoolManager,
+    ResourceUsage,
+    StoreUnavailable,
+    terminal_job_ids,
+)
 from .resource_requirements import extract_resource_requirements_from_tool
 
 log = logging.getLogger(__name__)
@@ -41,8 +51,17 @@ class EntityToDestinationMapper(object):
         self.destinations = self.config.destinations
         self.default_inherits = self.config.global_config.default_inherits
         self.global_context = self.config.global_config.context
-        pool_config = self.config.global_config.resource_pools
-        self.resource_pools = ResourcePoolManager(pool_config) if pool_config else None
+        self.pools = self.config.pools
+        store_config = self.config.global_config.resource_pool_store
+        if self.pools and store_config is None:
+            # Fail loudly rather than silently disabling enforcement: a config that declares pool
+            # policy but omits the store wiring would otherwise be fail-open by omission.
+            raise ValueError(
+                "Resource pools are configured under 'pools:' but 'global.resource_pool_store' is "
+                "not set. Add the store wiring (e.g. a ValkeyAllocationStore) so enforcement is "
+                "active, or remove the pools."
+            )
+        self.resource_pools = ResourcePoolManager(store_config) if store_config else None
         self.lookup_tool_regex = functools.lru_cache(maxsize=None)(self.__compile_tool_regex)
         self._cache_inherit_matching_entities: Any = Cache(maxsize=0)
 
@@ -317,6 +336,112 @@ class EntityToDestinationMapper(object):
 
         return evaluated_entity
 
+    @staticmethod
+    def _exceeds(req: ResourceUsage, budget: Budget) -> bool:
+        return (
+            (budget.cores is not None and req.cores > budget.cores)
+            or (budget.mem is not None and req.mem > budget.mem)
+            or (budget.gpus is not None and req.gpus > budget.gpus)
+        )
+
+    def _classify_pool_request(self, name: str, req: ResourceUsage, budget: Budget, pool: PoolEntity) -> str:
+        """Return NORMAL or OVERSIZE for a request, or raise JobMappingException if the request
+        can never be scheduled in this pool (oversize not allowed, or beyond a hard_max ceiling)."""
+        if not self._exceeds(req, budget):
+            return NORMAL
+        ceiling = Budget(
+            cores=pool.oversize.hard_max_cores,
+            mem=pool.oversize.hard_max_mem,
+            gpus=pool.oversize.hard_max_gpus,
+        )
+        if pool.oversize.max_concurrent <= 0 or self._exceeds(req, ceiling):
+            raise JobMappingException(  # type: ignore[no-untyped-call]
+                f"This job requests cores={req.cores}, mem={req.mem}, gpus={req.gpus}, which "
+                f"exceeds your '{name}' resource pool allocation and can never be scheduled."
+            )
+        return OVERSIZE
+
+    def admit_to_pools(self, context: dict[str, Any], entity: Entity, user: GalaxyUser | None) -> None:
+        """Check the job about to be scheduled against every resource pool that applies to it,
+        and either record its usage or refuse it.
+
+        A pool "applies" to a job when the job's scheduling tags match the pool's tags. For each
+        applying pool we add up everything the user is already running in that pool and check
+        whether this job still fits the budget:
+
+        - Fits -> record it and continue.
+        - Would push the user over budget -> defer the job (raise ``JobNotReadyException``, i.e.
+          "not now, try again later").
+        - The job's *own* request is bigger than the whole budget ("oversize") -> allow it only
+          if the pool permits oversize jobs (``oversize.max_concurrent``) and there is a free
+          oversize slot, otherwise defer it; if oversize is not allowed at all, or the request
+          is above the pool's ``hard_max_*`` ceiling, reject it permanently (raise
+          ``JobMappingException``, i.e. "this can never run here").
+
+        The budget is the user's/role's ``max_concurrent_*`` if they set one, otherwise the
+        pool's default. Anonymous (logged-out) jobs are not subject to per-user pools.
+
+        A note on two deliberate choices:
+
+        - We bill the job for what it *requests*, measured here, before a destination gets to
+          shrink it. A destination that caps cores does not reduce what the pool counts.
+        - We record usage as soon as we know a destination exists, before we finish picking one.
+          So a job can briefly hold a slot and then still be deferred (e.g. a second pool defers
+          it, or every candidate destination turns it away). We prefer this: counting a
+          not-yet-running job costs the user a slot for a moment, whereas *not* counting it could
+          let them exceed the limit -- the wrong direction for a safety cap. The overcount is
+          temporary: when the deferred job is retried it replaces its own old entry (see
+          ``AllocationStore.admit``), so nothing leaks permanently. A tighter scheme (reserve all
+          pools first, commit together, and release on a later failure) is possible but not yet
+          built.
+
+        If the allocation store is unreachable we default to deferring the job ("fail-closed" --
+        when we can't check, we say no) so an outage can't silently let users exceed their
+        limits. A pool may set ``fail_open`` to admit instead ("when we can't check, let it
+        through"); see :class:`~tpv.core.entities.PoolEntity`.
+        """
+        manager = self.resource_pools
+        if manager is None or not self.pools or user is None:
+            return
+        # Evaluate the requested resources once, here. evaluate_resources writes cores/mem/gpus
+        # onto the context it is given, so use a shallow copy to avoid polluting live evaluation.
+        evaluated = entity.evaluate_resources(copy.copy(context))
+        req = ResourceUsage(
+            cores=float(evaluated.cores or 0),
+            mem=float(evaluated.mem or 0),
+            gpus=float(evaluated.gpus or 0),
+        )
+        app = context["app"]
+        job = context["job"]
+        for name in sorted(self.pools):
+            pool = self.pools[name]
+            if not pool.matches(entity):
+                continue
+            budget = pool.budget_for(entity)
+            kind = self._classify_pool_request(name, req, budget, pool)
+            try:
+                ledger_ids = set(manager.store.read(name, user.id).keys())
+                drop = terminal_job_ids(app.model.context, ledger_ids)
+                admitted = manager.store.admit(
+                    name,
+                    user.id,
+                    job.id,
+                    req,
+                    kind=kind,
+                    budget=budget,
+                    max_oversize=pool.oversize.max_concurrent,
+                    reserve_pool=pool.oversize.reserve_pool,
+                    drop_job_ids=drop,
+                )
+            except StoreUnavailable:
+                if pool.fail_open:
+                    log.warning("Resource pool '%s' store is unavailable; admitting job (fail_open)", name)
+                    continue
+                log.warning("Resource pool '%s' store is unavailable; deferring job (fail-closed)", name)
+                raise JobNotReadyException()  # type: ignore[no-untyped-call]
+            if not admitted:
+                raise JobNotReadyException()  # type: ignore[no-untyped-call]
+
     def map_to_destination(
         self,
         app: UniverseApplication,
@@ -344,9 +469,6 @@ class EntityToDestinationMapper(object):
                 "mapper": self,
             }
         )
-        # Expose the context dict itself so rule code can hand the full evaluation context to
-        # helpers (e.g. helpers.enforce_resource_pool) that need to evaluate entity resources.
-        context["context"] = context
 
         # Inject the explain collector into the context
         if explain_collector:
@@ -360,7 +482,12 @@ class EntityToDestinationMapper(object):
 
         explain = ExplainCollector.from_context(context)
 
-        # 4. Fully combine entity with matching destinations
+        # 4. Admit the job to any resource pools that govern it, now that we know a destination
+        #    exists (so we never record an allocation for a job with nowhere to run).
+        if ranked_dest_entities:
+            self.admit_to_pools(context, evaluated_entity, user)
+
+        # 5. Fully combine entity with matching destinations
         if ranked_dest_entities:
             wait_exception_raised = False
             for d in ranked_dest_entities:

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -25,6 +25,7 @@ from .entities import (
 )
 from .explain import ExplainCollector, ExplainPhase
 from .loader import TPVConfigLoader
+from .resource_pool import ResourcePoolManager
 from .resource_requirements import extract_resource_requirements_from_tool
 
 log = logging.getLogger(__name__)
@@ -40,6 +41,8 @@ class EntityToDestinationMapper(object):
         self.destinations = self.config.destinations
         self.default_inherits = self.config.global_config.default_inherits
         self.global_context = self.config.global_config.context
+        pool_config = self.config.global_config.resource_pools
+        self.resource_pools = ResourcePoolManager(pool_config) if pool_config else None
         self.lookup_tool_regex = functools.lru_cache(maxsize=None)(self.__compile_tool_regex)
         self._cache_inherit_matching_entities: Any = Cache(maxsize=0)
 
@@ -341,6 +344,9 @@ class EntityToDestinationMapper(object):
                 "mapper": self,
             }
         )
+        # Expose the context dict itself so rule code can hand the full evaluation context to
+        # helpers (e.g. helpers.enforce_resource_pool) that need to evaluate entity resources.
+        context["context"] = context
 
         # Inject the explain collector into the context
         if explain_collector:

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -30,6 +30,7 @@ from .loader import TPVConfigLoader
 from .resource_pool import (
     NORMAL,
     OVERSIZE,
+    AllocationStore,
     Budget,
     PoolAdmission,
     ResourcePoolManager,
@@ -46,7 +47,7 @@ EntityType = TypeVar("EntityType", bound=Entity)
 
 class EntityToDestinationMapper(object):
 
-    def __init__(self, loader: TPVConfigLoader):
+    def __init__(self, loader: TPVConfigLoader, resource_pool_store: AllocationStore | None = None):
         self.loader = loader
         self.config = loader.config
         self.destinations = self.config.destinations
@@ -62,7 +63,12 @@ class EntityToDestinationMapper(object):
                 "not set. Add the store wiring (e.g. a ValkeyAllocationStore) so enforcement is "
                 "active, or remove the pools."
             )
-        self.resource_pools = ResourcePoolManager(store_config) if store_config else None
+        if resource_pool_store is not None:
+            # Caller-supplied store (a dry run passes an in-memory one so it never reads from or
+            # writes to the deployment's accounting). The config check above still applies.
+            self.resource_pools: ResourcePoolManager | None = ResourcePoolManager(resource_pool_store)
+        else:
+            self.resource_pools = ResourcePoolManager(store_config.build_store()) if store_config else None
         self.lookup_tool_regex = functools.lru_cache(maxsize=None)(self.__compile_tool_regex)
         self._cache_inherit_matching_entities: Any = Cache(maxsize=0)
 
@@ -412,26 +418,56 @@ class EntityToDestinationMapper(object):
         )
         app = context["app"]
         job = context["job"]
+        explain = ExplainCollector.from_context(context)
         admissions = []
         # Resolve every matching pool before the single admission transaction.
         for name, pool in sorted(self.pools.items()):
             if not pool.matches(entity):
                 continue
             budget = pool.budget_for(entity)
-            kind = self._classify_pool_request(name, req, budget, pool)
+            try:
+                kind = self._classify_pool_request(name, req, budget, pool)
+            except JobMappingException as e:
+                if explain:
+                    explain.add_step(ExplainPhase.RESOURCE_POOLS, f"Pool '{name}': REJECTED", str(e))
+                raise
+            if explain:
+                explain.add_step(
+                    ExplainPhase.RESOURCE_POOLS,
+                    f"Pool '{name}' governs this job: request is {kind}",
+                    f"request: cores={req.cores}, mem={req.mem}, gpus={req.gpus}\n"
+                    f"budget:  cores={budget.cores}, mem={budget.mem}, gpus={budget.gpus}"
+                    + (
+                        f"\noversize: max_jobs={pool.oversize.max_concurrent}, "
+                        f"hard_max cores={pool.oversize.hard_max_cores}, mem={pool.oversize.hard_max_mem}, "
+                        f"gpus={pool.oversize.hard_max_gpus}"
+                        if kind == OVERSIZE
+                        else ""
+                    ),
+                )
             try:
                 ledger_ids = set(manager.store.read(name, user.id))
             except StoreUnavailable:
                 if pool.fail_open:
                     log.warning("Resource pool '%s' store is unavailable; admitting job (fail_open)", name)
+                    if explain:
+                        explain.add_step(
+                            ExplainPhase.RESOURCE_POOLS, f"Pool '{name}': store unavailable, fail_open -> admitted"
+                        )
                     continue
                 log.warning("Resource pool '%s' store is unavailable; deferring job (fail-closed)", name)
+                if explain:
+                    explain.add_step(
+                        ExplainPhase.RESOURCE_POOLS, f"Pool '{name}': store unavailable, fail-closed -> deferred"
+                    )
                 raise JobNotReadyException()  # type: ignore[no-untyped-call]
             drop = terminal_job_ids(app.model.context, ledger_ids)
             admissions.append(
                 PoolAdmission(name, req, kind, budget, pool.oversize.max_concurrent, pool.oversize.reserve_pool, drop)
             )
         if not admissions:
+            if explain:
+                explain.add_step(ExplainPhase.RESOURCE_POOLS, "No resource pools govern this job")
             return
         try:
             admitted = manager.store.admit_many(user.id, job.id, admissions)
@@ -440,11 +476,24 @@ class EntityToDestinationMapper(object):
             # one opted into fail-open. A permissive pool cannot weaken a strict pool.
             if all(self.pools[a.pool].fail_open for a in admissions):
                 log.warning("Resource pool store is unavailable; admitting job (all pools fail_open)")
+                if explain:
+                    explain.add_step(
+                        ExplainPhase.RESOURCE_POOLS, "Store unavailable; every pool is fail_open -> admitted"
+                    )
                 return
             log.warning("Resource pool store is unavailable; deferring job (fail-closed)")
+            if explain:
+                explain.add_step(ExplainPhase.RESOURCE_POOLS, "Store unavailable; fail-closed -> deferred")
             raise JobNotReadyException()  # type: ignore[no-untyped-call]
+        pool_names = ", ".join(a.pool for a in admissions)
         if not admitted:
+            if explain:
+                explain.add_step(
+                    ExplainPhase.RESOURCE_POOLS, f"DEFERRED: user's current usage leaves no room in: {pool_names}"
+                )
             raise JobNotReadyException()  # type: ignore[no-untyped-call]
+        if explain:
+            explain.add_step(ExplainPhase.RESOURCE_POOLS, f"Admitted and recorded in: {pool_names}")
 
     def map_to_destination(
         self,

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -25,6 +25,7 @@ from .entities import (
 )
 from .explain import ExplainCollector, ExplainPhase
 from .loader import TPVConfigLoader
+from .resource_pool import ResourcePoolManager
 from .resource_requirements import extract_resource_requirements_from_tool
 
 log = logging.getLogger(__name__)
@@ -40,6 +41,8 @@ class EntityToDestinationMapper(object):
         self.destinations = self.config.destinations
         self.default_inherits = self.config.global_config.default_inherits
         self.global_context = self.config.global_config.context
+        pool_config = self.config.global_config.resource_pools
+        self.resource_pools = ResourcePoolManager(pool_config) if pool_config else None
         self.lookup_tool_regex = functools.lru_cache(maxsize=None)(self.__compile_tool_regex)
         self._cache_inherit_matching_entities: Any = Cache(maxsize=0)
 
@@ -352,6 +355,9 @@ class EntityToDestinationMapper(object):
                 "mapper": self,
             }
         )
+        # Expose the context dict itself so rule code can hand the full evaluation context to
+        # helpers (e.g. helpers.enforce_resource_pool) that need to evaluate entity resources.
+        context["context"] = context
 
         # Inject the explain collector into the context
         if explain_collector:

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -31,6 +31,7 @@ from .resource_pool import (
     NORMAL,
     OVERSIZE,
     Budget,
+    PoolAdmission,
     ResourcePoolManager,
     ResourceUsage,
     StoreUnavailable,
@@ -392,19 +393,9 @@ class EntityToDestinationMapper(object):
         The budget is the user's/role's ``max_concurrent_*`` if they set one, otherwise the
         pool's default. Anonymous (logged-out) jobs are not subject to per-user pools.
 
-        A note on two deliberate choices:
-
-        - We bill the job for what it *requests*, measured here, before a destination gets to
-          shrink it. A destination that caps cores does not reduce what the pool counts.
-        - We record usage as soon as we know a destination exists, before we finish picking one.
-          So a job can briefly hold a slot and then still be deferred (e.g. a second pool defers
-          it, or every candidate destination turns it away). We prefer this: counting a
-          not-yet-running job costs the user a slot for a moment, whereas *not* counting it could
-          let them exceed the limit -- the wrong direction for a safety cap. The overcount is
-          temporary: when the deferred job is retried it replaces its own old entry (see
-          ``AllocationStore.admit``), so nothing leaks permanently. A tighter scheme (reserve all
-          pools first, commit together, and release on a later failure) is possible but not yet
-          built.
+        The entity carries the request evaluated before destination rules or clamping. Admission
+        runs only after a destination has evaluated and converted successfully. All matching
+        pools are checked and recorded atomically so deferral cannot leave partial reservations.
 
         If the allocation store is unreachable we default to deferring the job ("fail-closed" --
         when we can't check, we say no) so an outage can't silently let users exceed their
@@ -414,44 +405,46 @@ class EntityToDestinationMapper(object):
         manager = self.resource_pools
         if manager is None or not self.pools or user is None:
             return
-        # Evaluate the requested resources once, here. evaluate_resources writes cores/mem/gpus
-        # onto the context it is given, so use a shallow copy to avoid polluting live evaluation.
-        evaluated = entity.evaluate_resources(copy.copy(context))
         req = ResourceUsage(
-            cores=float(evaluated.cores or 0),
-            mem=float(evaluated.mem or 0),
-            gpus=float(evaluated.gpus or 0),
+            cores=float(entity.cores or 0),
+            mem=float(entity.mem or 0),
+            gpus=float(entity.gpus or 0),
         )
         app = context["app"]
         job = context["job"]
-        for name in sorted(self.pools):
-            pool = self.pools[name]
+        admissions = []
+        # Resolve every matching pool before the single admission transaction.
+        for name, pool in sorted(self.pools.items()):
             if not pool.matches(entity):
                 continue
             budget = pool.budget_for(entity)
             kind = self._classify_pool_request(name, req, budget, pool)
             try:
-                ledger_ids = set(manager.store.read(name, user.id).keys())
-                drop = terminal_job_ids(app.model.context, ledger_ids)
-                admitted = manager.store.admit(
-                    name,
-                    user.id,
-                    job.id,
-                    req,
-                    kind=kind,
-                    budget=budget,
-                    max_oversize=pool.oversize.max_concurrent,
-                    reserve_pool=pool.oversize.reserve_pool,
-                    drop_job_ids=drop,
-                )
+                ledger_ids = set(manager.store.read(name, user.id))
             except StoreUnavailable:
                 if pool.fail_open:
                     log.warning("Resource pool '%s' store is unavailable; admitting job (fail_open)", name)
                     continue
                 log.warning("Resource pool '%s' store is unavailable; deferring job (fail-closed)", name)
                 raise JobNotReadyException()  # type: ignore[no-untyped-call]
-            if not admitted:
-                raise JobNotReadyException()  # type: ignore[no-untyped-call]
+            drop = terminal_job_ids(app.model.context, ledger_ids)
+            admissions.append(
+                PoolAdmission(name, req, kind, budget, pool.oversize.max_concurrent, pool.oversize.reserve_pool, drop)
+            )
+        if not admissions:
+            return
+        try:
+            admitted = manager.store.admit_many(user.id, job.id, admissions)
+        except StoreUnavailable:
+            # A batch write failure affects every included pool, so bypass it only if every
+            # one opted into fail-open. A permissive pool cannot weaken a strict pool.
+            if all(self.pools[a.pool].fail_open for a in admissions):
+                log.warning("Resource pool store is unavailable; admitting job (all pools fail_open)")
+                return
+            log.warning("Resource pool store is unavailable; deferring job (fail-closed)")
+            raise JobNotReadyException()  # type: ignore[no-untyped-call]
+        if not admitted:
+            raise JobNotReadyException()  # type: ignore[no-untyped-call]
 
     def map_to_destination(
         self,
@@ -493,12 +486,12 @@ class EntityToDestinationMapper(object):
 
         explain = ExplainCollector.from_context(context)
 
-        # 4. Admit the job to any resource pools that govern it, now that we know a destination
-        #    exists (so we never record an allocation for a job with nowhere to run).
-        if ranked_dest_entities:
-            self.admit_to_pools(context, evaluated_entity, user)
+        # Capture the requested resources before destination evaluation changes the context.
+        pool_entity = evaluated_entity
+        if ranked_dest_entities and self.pools and user is not None:
+            pool_entity = evaluated_entity.evaluate_resources(copy.copy(context))
 
-        # 5. Fully combine entity with matching destinations
+        # 4. Fully combine entity with matching destinations
         if ranked_dest_entities:
             wait_exception_raised = False
             for d in ranked_dest_entities:
@@ -510,7 +503,9 @@ class EntityToDestinationMapper(object):
                         )
                     dest_combined_entity = d.combine(cast(Destination, evaluated_entity))
                     evaluated_destination = dest_combined_entity.evaluate(context)
-                    # 5. Return the top-ranked destination that evaluates successfully
+                    destination = self.to_galaxy_destination(evaluated_destination)
+                    # 5. Commit all pool allocations only when this mapping can be returned.
+                    self.admit_to_pools(context, pool_entity, user)
                     if explain:
                         explain.add_step(
                             ExplainPhase.FINAL_RESULT,
@@ -521,7 +516,7 @@ class EntityToDestinationMapper(object):
                             f"params: {evaluated_destination.params}\n"
                             f"env: {evaluated_destination.env}",
                         )
-                    return self.to_galaxy_destination(evaluated_destination)
+                    return destination
                 except TryNextDestinationOrFail as ef:
                     if explain:
                         explain.add_step(

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import logging
 import re
@@ -7,7 +8,7 @@ from typing import Any, TypeVar, cast
 from cachetools import Cache, cached
 from galaxy.app import UniverseApplication
 from galaxy.jobs import JobDestination, JobWrapper, ResubmitConfigDict
-from galaxy.jobs.mapper import JobNotReadyException
+from galaxy.jobs.mapper import JobMappingException, JobNotReadyException
 from galaxy.model import Job
 from galaxy.model import User as GalaxyUser
 from galaxy.tools import Tool as GalaxyTool
@@ -16,6 +17,7 @@ from .entities import (
     Destination,
     Entity,
     EntityWithRules,
+    PoolEntity,
     Role,
     SchedulingTags,
     Tool,
@@ -25,7 +27,15 @@ from .entities import (
 )
 from .explain import ExplainCollector, ExplainPhase
 from .loader import TPVConfigLoader
-from .resource_pool import ResourcePoolManager
+from .resource_pool import (
+    NORMAL,
+    OVERSIZE,
+    Budget,
+    ResourcePoolManager,
+    ResourceUsage,
+    StoreUnavailable,
+    terminal_job_ids,
+)
 from .resource_requirements import extract_resource_requirements_from_tool
 
 log = logging.getLogger(__name__)
@@ -41,8 +51,17 @@ class EntityToDestinationMapper(object):
         self.destinations = self.config.destinations
         self.default_inherits = self.config.global_config.default_inherits
         self.global_context = self.config.global_config.context
-        pool_config = self.config.global_config.resource_pools
-        self.resource_pools = ResourcePoolManager(pool_config) if pool_config else None
+        self.pools = self.config.pools
+        store_config = self.config.global_config.resource_pool_store
+        if self.pools and store_config is None:
+            # Fail loudly rather than silently disabling enforcement: a config that declares pool
+            # policy but omits the store wiring would otherwise be fail-open by omission.
+            raise ValueError(
+                "Resource pools are configured under 'pools:' but 'global.resource_pool_store' is "
+                "not set. Add the store wiring (e.g. a ValkeyAllocationStore) so enforcement is "
+                "active, or remove the pools."
+            )
+        self.resource_pools = ResourcePoolManager(store_config) if store_config else None
         self.lookup_tool_regex = functools.lru_cache(maxsize=None)(self.__compile_tool_regex)
         self._cache_inherit_matching_entities: Any = Cache(maxsize=0)
 
@@ -328,6 +347,112 @@ class EntityToDestinationMapper(object):
 
         return evaluated_entity
 
+    @staticmethod
+    def _exceeds(req: ResourceUsage, budget: Budget) -> bool:
+        return (
+            (budget.cores is not None and req.cores > budget.cores)
+            or (budget.mem is not None and req.mem > budget.mem)
+            or (budget.gpus is not None and req.gpus > budget.gpus)
+        )
+
+    def _classify_pool_request(self, name: str, req: ResourceUsage, budget: Budget, pool: PoolEntity) -> str:
+        """Return NORMAL or OVERSIZE for a request, or raise JobMappingException if the request
+        can never be scheduled in this pool (oversize not allowed, or beyond a hard_max ceiling)."""
+        if not self._exceeds(req, budget):
+            return NORMAL
+        ceiling = Budget(
+            cores=pool.oversize.hard_max_cores,
+            mem=pool.oversize.hard_max_mem,
+            gpus=pool.oversize.hard_max_gpus,
+        )
+        if pool.oversize.max_concurrent <= 0 or self._exceeds(req, ceiling):
+            raise JobMappingException(  # type: ignore[no-untyped-call]
+                f"This job requests cores={req.cores}, mem={req.mem}, gpus={req.gpus}, which "
+                f"exceeds your '{name}' resource pool allocation and can never be scheduled."
+            )
+        return OVERSIZE
+
+    def admit_to_pools(self, context: dict[str, Any], entity: Entity, user: GalaxyUser | None) -> None:
+        """Check the job about to be scheduled against every resource pool that applies to it,
+        and either record its usage or refuse it.
+
+        A pool "applies" to a job when the job's scheduling tags match the pool's tags. For each
+        applying pool we add up everything the user is already running in that pool and check
+        whether this job still fits the budget:
+
+        - Fits -> record it and continue.
+        - Would push the user over budget -> defer the job (raise ``JobNotReadyException``, i.e.
+          "not now, try again later").
+        - The job's *own* request is bigger than the whole budget ("oversize") -> allow it only
+          if the pool permits oversize jobs (``oversize.max_concurrent``) and there is a free
+          oversize slot, otherwise defer it; if oversize is not allowed at all, or the request
+          is above the pool's ``hard_max_*`` ceiling, reject it permanently (raise
+          ``JobMappingException``, i.e. "this can never run here").
+
+        The budget is the user's/role's ``max_concurrent_*`` if they set one, otherwise the
+        pool's default. Anonymous (logged-out) jobs are not subject to per-user pools.
+
+        A note on two deliberate choices:
+
+        - We bill the job for what it *requests*, measured here, before a destination gets to
+          shrink it. A destination that caps cores does not reduce what the pool counts.
+        - We record usage as soon as we know a destination exists, before we finish picking one.
+          So a job can briefly hold a slot and then still be deferred (e.g. a second pool defers
+          it, or every candidate destination turns it away). We prefer this: counting a
+          not-yet-running job costs the user a slot for a moment, whereas *not* counting it could
+          let them exceed the limit -- the wrong direction for a safety cap. The overcount is
+          temporary: when the deferred job is retried it replaces its own old entry (see
+          ``AllocationStore.admit``), so nothing leaks permanently. A tighter scheme (reserve all
+          pools first, commit together, and release on a later failure) is possible but not yet
+          built.
+
+        If the allocation store is unreachable we default to deferring the job ("fail-closed" --
+        when we can't check, we say no) so an outage can't silently let users exceed their
+        limits. A pool may set ``fail_open`` to admit instead ("when we can't check, let it
+        through"); see :class:`~tpv.core.entities.PoolEntity`.
+        """
+        manager = self.resource_pools
+        if manager is None or not self.pools or user is None:
+            return
+        # Evaluate the requested resources once, here. evaluate_resources writes cores/mem/gpus
+        # onto the context it is given, so use a shallow copy to avoid polluting live evaluation.
+        evaluated = entity.evaluate_resources(copy.copy(context))
+        req = ResourceUsage(
+            cores=float(evaluated.cores or 0),
+            mem=float(evaluated.mem or 0),
+            gpus=float(evaluated.gpus or 0),
+        )
+        app = context["app"]
+        job = context["job"]
+        for name in sorted(self.pools):
+            pool = self.pools[name]
+            if not pool.matches(entity):
+                continue
+            budget = pool.budget_for(entity)
+            kind = self._classify_pool_request(name, req, budget, pool)
+            try:
+                ledger_ids = set(manager.store.read(name, user.id).keys())
+                drop = terminal_job_ids(app.model.context, ledger_ids)
+                admitted = manager.store.admit(
+                    name,
+                    user.id,
+                    job.id,
+                    req,
+                    kind=kind,
+                    budget=budget,
+                    max_oversize=pool.oversize.max_concurrent,
+                    reserve_pool=pool.oversize.reserve_pool,
+                    drop_job_ids=drop,
+                )
+            except StoreUnavailable:
+                if pool.fail_open:
+                    log.warning("Resource pool '%s' store is unavailable; admitting job (fail_open)", name)
+                    continue
+                log.warning("Resource pool '%s' store is unavailable; deferring job (fail-closed)", name)
+                raise JobNotReadyException()  # type: ignore[no-untyped-call]
+            if not admitted:
+                raise JobNotReadyException()  # type: ignore[no-untyped-call]
+
     def map_to_destination(
         self,
         app: UniverseApplication,
@@ -355,9 +480,6 @@ class EntityToDestinationMapper(object):
                 "mapper": self,
             }
         )
-        # Expose the context dict itself so rule code can hand the full evaluation context to
-        # helpers (e.g. helpers.enforce_resource_pool) that need to evaluate entity resources.
-        context["context"] = context
 
         # Inject the explain collector into the context
         if explain_collector:
@@ -371,7 +493,12 @@ class EntityToDestinationMapper(object):
 
         explain = ExplainCollector.from_context(context)
 
-        # 4. Fully combine entity with matching destinations
+        # 4. Admit the job to any resource pools that govern it, now that we know a destination
+        #    exists (so we never record an allocation for a job with nowhere to run).
+        if ranked_dest_entities:
+            self.admit_to_pools(context, evaluated_entity, user)
+
+        # 5. Fully combine entity with matching destinations
         if ranked_dest_entities:
             wait_exception_raised = False
             for d in ranked_dest_entities:

--- a/tpv/core/resource_pool.py
+++ b/tpv/core/resource_pool.py
@@ -24,10 +24,10 @@ import importlib
 import logging
 import threading
 from abc import ABC, abstractmethod
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, cast
 
 from galaxy import model
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session, scoped_session
 
 log = logging.getLogger(__name__)
@@ -75,8 +75,11 @@ class Budget(NamedTuple):
 
 
 # ---------------------------------------------------------------------------
-# Configuration models (declared under ``global.resource_pools`` in TPV config)
+# Configuration models
 # ---------------------------------------------------------------------------
+# Pool *policy* (budgets, oversize, tags) is expressed as first-class ``pools:`` entities in
+# ``tpv.core.entities`` (see :class:`~tpv.core.entities.PoolEntity`). Only the *infrastructure*
+# wiring for the allocation store lives here, declared under ``global.resource_pool_store``.
 class OversizePolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -92,22 +95,26 @@ class OversizePolicy(BaseModel):
     reserve_pool: bool = False
 
 
-class Pool(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class StoreConfig(BaseModel):
+    """Infrastructure wiring for the allocation store, declared under
+    ``global.resource_pool_store``. Only backend wiring belongs here -- a store class plus its
+    options (url, ttl, key_prefix, ...); pool *policy* is expressed as ``pools:`` entities::
 
-    max_cores: float | None = None
-    max_mem: float | None = None
-    max_gpus: float | None = None
-    oversize: OversizePolicy = OversizePolicy()
+        global:
+          resource_pool_store:
+            class: tpv.core.resource_pool.ValkeyAllocationStore
+            url: valkey://localhost:6379/0
+            ttl: 3600
+    """
 
+    # Extra keys (url, ttl, key_prefix, ...) are collected and passed to the store constructor.
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
-class ResourcePoolConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    store_class: str = Field(alias="class", default="tpv.core.resource_pool.ValkeyAllocationStore")
 
-    store: str = "tpv.core.resource_pool.ValkeyAllocationStore"
-    store_options: dict[str, Any] = {}
-    budget_provider: str = "tpv.core.resource_pool.ConfigBudgetProvider"
-    pools: dict[str, Pool] = {}
+    def build_store(self) -> "AllocationStore":
+        options = dict(self.__pydantic_extra__ or {})
+        return cast("AllocationStore", _load_class(self.store_class)(**options))
 
 
 def _load_class(dotted_path: str) -> Any:
@@ -115,30 +122,6 @@ def _load_class(dotted_path: str) -> Any:
     if not module_path:
         raise ValueError(f"Not a dotted class path: {dotted_path!r}")
     return getattr(importlib.import_module(module_path), name)
-
-
-# ---------------------------------------------------------------------------
-# Budget providers
-# ---------------------------------------------------------------------------
-class BudgetProvider(ABC):
-    """Resolves the :class:`Budget` for a ``(user, pool)``. Pluggable so deployments can vary
-    budgets by user/role/group or an external service without changing the helper."""
-
-    @abstractmethod
-    def budget_for(self, user: Any, pool_name: str) -> Budget: ...
-
-
-class ConfigBudgetProvider(BudgetProvider):
-    """Default provider: one flat budget per pool from the TPV config, for every user."""
-
-    def __init__(self, config: ResourcePoolConfig):
-        self.config = config
-
-    def budget_for(self, user: Any, pool_name: str) -> Budget:
-        pool = self.config.pools.get(pool_name)
-        if pool is None:
-            return Budget()
-        return Budget(cores=pool.max_cores, mem=pool.max_mem, gpus=pool.max_gpus)
 
 
 # ---------------------------------------------------------------------------
@@ -367,18 +350,15 @@ class ValkeyAllocationStore(AllocationStore):
 
 
 class ResourcePoolManager:
-    """Instantiates and holds the pluggable store and budget provider for a loaded config.
+    """Instantiates and holds the pluggable allocation store for a loaded config.
 
-    One is created per mapper (see :class:`tpv.core.mapper.EntityToDestinationMapper`).
+    This is pure infrastructure: pool *policy* (budgets, oversize, tags) lives on the
+    first-class ``pools:`` entities and is resolved by the mapper. One manager is created per
+    mapper (see :class:`tpv.core.mapper.EntityToDestinationMapper`).
     """
 
-    def __init__(self, config: ResourcePoolConfig):
-        self.config = config
-        self.store: AllocationStore = _load_class(config.store)(**(config.store_options or {}))
-        self.provider: BudgetProvider = _load_class(config.budget_provider)(config)
-
-    def pool(self, name: str) -> Pool | None:
-        return self.config.pools.get(name)
+    def __init__(self, store_config: StoreConfig):
+        self.store: AllocationStore = store_config.build_store()
 
 
 def terminal_job_ids(sa_session: scoped_session[Session], job_ids: set[int]) -> set[int]:

--- a/tpv/core/resource_pool.py
+++ b/tpv/core/resource_pool.py
@@ -1,0 +1,398 @@
+"""Per-user resource pools.
+
+A *resource pool* caps how much aggregate compute (cores/memory/GPUs) a single user may
+consume across their concurrently active jobs. This is a prerequisite for safely exposing
+User Defined Tools (UDTs), where a user could otherwise submit many jobs and monopolise the
+cluster.
+
+Accounting is kept in an external **allocation store** (Valkey by default), *not* in Galaxy's
+database, which is a permanent home for data and not the right place for ephemeral
+allocations. The store holds, per ``(pool, user)``, a ledger of ``{job_id: allocation}`` for
+the jobs TPV has admitted to the pool. Galaxy's job table is consulted read-only to discover
+which ledgered jobs have reached a terminal state so their allocation can be released --
+TPV never needs a job-completion callback.
+
+The load-bearing operation is :meth:`AllocationStore.admit`, a single atomic
+check-and-record: it drops finished jobs, sums the remaining committed usage and, if the
+incoming job fits the budget (or the oversize allowance), records it. Because it is atomic,
+two concurrent maps for the same user cannot both squeak past the budget.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import threading
+from abc import ABC, abstractmethod
+from typing import Any, NamedTuple
+
+from galaxy import model
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session, scoped_session
+
+log = logging.getLogger(__name__)
+
+# Galaxy job states that mean a job no longer holds any allocation. Anything not in this set
+# (new, queued, running, resubmitted, or a job row we cannot see yet) is treated as live and
+# keeps its ledger entry -- releasing only on positive evidence of completion is the
+# conservative, never-overshoot choice.
+TERMINAL_JOB_STATES = (
+    "ok",
+    "error",
+    "failed",
+    "deleted",
+    "deleting",
+    "stopped",
+    "stopping",
+    "paused",
+    "skipped",
+)
+
+NORMAL = "normal"
+OVERSIZE = "oversize"
+
+
+class StoreUnavailable(Exception):
+    """Raised by an :class:`AllocationStore` when its backend cannot be reached.
+
+    The caller treats this as fail-closed: a job governed by a pool is deferred rather than
+    admitted, so an outage of the store never silently bypasses enforcement.
+    """
+
+
+class ResourceUsage(NamedTuple):
+    cores: float = 0.0
+    mem: float = 0.0
+    gpus: float = 0.0
+
+
+class Budget(NamedTuple):
+    """A pool budget. ``None`` on a dimension means unlimited for that dimension."""
+
+    cores: float | None = None
+    mem: float | None = None
+    gpus: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Configuration models (declared under ``global.resource_pools`` in TPV config)
+# ---------------------------------------------------------------------------
+class OversizePolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # How many over-budget jobs a user may run concurrently in this pool. 0 (the default)
+    # means over-budget jobs are rejected outright -- the correct setting for UDT pools.
+    max_concurrent: int = 0
+    # Optional absolute ceiling; a job requesting more than this always fails, even within
+    # the oversize allowance.
+    hard_max_cores: float | None = None
+    hard_max_mem: float | None = None
+    hard_max_gpus: float | None = None
+    # When true, a pool holds either normal jobs or a single oversize job, never both.
+    reserve_pool: bool = False
+
+
+class Pool(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    max_cores: float | None = None
+    max_mem: float | None = None
+    max_gpus: float | None = None
+    oversize: OversizePolicy = OversizePolicy()
+
+
+class ResourcePoolConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    store: str = "tpv.core.resource_pool.ValkeyAllocationStore"
+    store_options: dict[str, Any] = {}
+    budget_provider: str = "tpv.core.resource_pool.ConfigBudgetProvider"
+    pools: dict[str, Pool] = {}
+
+
+def _load_class(dotted_path: str) -> Any:
+    module_path, _, name = dotted_path.rpartition(".")
+    if not module_path:
+        raise ValueError(f"Not a dotted class path: {dotted_path!r}")
+    return getattr(importlib.import_module(module_path), name)
+
+
+# ---------------------------------------------------------------------------
+# Budget providers
+# ---------------------------------------------------------------------------
+class BudgetProvider(ABC):
+    """Resolves the :class:`Budget` for a ``(user, pool)``. Pluggable so deployments can vary
+    budgets by user/role/group or an external service without changing the helper."""
+
+    @abstractmethod
+    def budget_for(self, user: Any, pool_name: str) -> Budget: ...
+
+
+class ConfigBudgetProvider(BudgetProvider):
+    """Default provider: one flat budget per pool from the TPV config, for every user."""
+
+    def __init__(self, config: ResourcePoolConfig):
+        self.config = config
+
+    def budget_for(self, user: Any, pool_name: str) -> Budget:
+        pool = self.config.pools.get(pool_name)
+        if pool is None:
+            return Budget()
+        return Budget(cores=pool.max_cores, mem=pool.max_mem, gpus=pool.max_gpus)
+
+
+# ---------------------------------------------------------------------------
+# Allocation stores
+# ---------------------------------------------------------------------------
+def _decide(
+    entries: dict[int, tuple[ResourceUsage, str]],
+    req: ResourceUsage,
+    kind: str,
+    budget: Budget,
+    max_oversize: int,
+    reserve_pool: bool,
+) -> bool:
+    """Pure admission decision shared by every store implementation."""
+    sum_normal = ResourceUsage(
+        cores=sum(u.cores for u, k in entries.values() if k == NORMAL),
+        mem=sum(u.mem for u, k in entries.values() if k == NORMAL),
+        gpus=sum(u.gpus for u, k in entries.values() if k == NORMAL),
+    )
+    count_oversize = sum(1 for _, k in entries.values() if k == OVERSIZE)
+    if kind == OVERSIZE:
+        if count_oversize >= max_oversize:
+            return False
+        if reserve_pool and (sum_normal.cores or sum_normal.mem or sum_normal.gpus):
+            return False
+        return True
+    # normal job
+    if reserve_pool and count_oversize:
+        return False
+    fits = (
+        (budget.cores is None or sum_normal.cores + req.cores <= budget.cores)
+        and (budget.mem is None or sum_normal.mem + req.mem <= budget.mem)
+        and (budget.gpus is None or sum_normal.gpus + req.gpus <= budget.gpus)
+    )
+    return fits
+
+
+class AllocationStore(ABC):
+    """Holds, per ``(pool, user)``, the ledger of admitted ``{job_id: allocation}``."""
+
+    @abstractmethod
+    def read(self, pool: str, user_id: int) -> dict[int, tuple[ResourceUsage, str]]:
+        """Return the current ledger as ``{job_id: (allocation, kind)}``."""
+
+    @abstractmethod
+    def admit(
+        self,
+        pool: str,
+        user_id: int,
+        job_id: int,
+        req: ResourceUsage,
+        *,
+        kind: str,
+        budget: Budget,
+        max_oversize: int,
+        reserve_pool: bool,
+        drop_job_ids: set[int],
+    ) -> bool:
+        """Atomically drop ``drop_job_ids`` (and ``job_id``'s own stale entry), then admit
+        ``job_id`` iff it fits. Returns True (admitted, entry recorded) or False (deferred,
+        ledger otherwise left as-is apart from the drops)."""
+
+
+class InMemoryAllocationStore(AllocationStore):
+    """Process-local store for tests and single-process deployments. Atomicity is provided by
+    a lock; it deliberately mirrors :class:`ValkeyAllocationStore`'s semantics (minus TTL)."""
+
+    def __init__(self, key_prefix: str = "tpv:pool", **_ignored: Any):
+        self.key_prefix = key_prefix
+        self._lock = threading.Lock()
+        self._data: dict[str, dict[int, tuple[ResourceUsage, str]]] = {}
+
+    def _key(self, pool: str, user_id: int) -> str:
+        return f"{self.key_prefix}:{pool}:user:{{{user_id}}}"
+
+    def read(self, pool: str, user_id: int) -> dict[int, tuple[ResourceUsage, str]]:
+        with self._lock:
+            return dict(self._data.get(self._key(pool, user_id), {}))
+
+    def admit(
+        self,
+        pool: str,
+        user_id: int,
+        job_id: int,
+        req: ResourceUsage,
+        *,
+        kind: str,
+        budget: Budget,
+        max_oversize: int,
+        reserve_pool: bool,
+        drop_job_ids: set[int],
+    ) -> bool:
+        key = self._key(pool, user_id)
+        with self._lock:
+            ledger = self._data.setdefault(key, {})
+            for jid in drop_job_ids:
+                ledger.pop(jid, None)
+            ledger.pop(job_id, None)
+            if _decide(ledger, req, kind, budget, max_oversize, reserve_pool):
+                ledger[job_id] = (req, kind)
+                return True
+            return False
+
+
+# Atomic admit for Valkey/Redis. Mirrors _decide(). KEYS[1] is the ledger key; ARGV is
+# [job_id, rc, rm, rg, kind, bc, bm, bg, max_oversize, reserve, ttl, drop_id...] where a
+# budget of -1 means "unlimited" for that dimension.
+_ADMIT_LUA = """
+local key = KEYS[1]
+local job_id = ARGV[1]
+local rc, rm, rg = tonumber(ARGV[2]), tonumber(ARGV[3]), tonumber(ARGV[4])
+local kind = ARGV[5]
+local bc, bm, bg = tonumber(ARGV[6]), tonumber(ARGV[7]), tonumber(ARGV[8])
+local max_oversize = tonumber(ARGV[9])
+local reserve = tonumber(ARGV[10])
+local ttl = tonumber(ARGV[11])
+redis.call('HDEL', key, job_id)
+for i = 12, #ARGV do redis.call('HDEL', key, ARGV[i]) end
+local flat = redis.call('HGETALL', key)
+local sum_c, sum_m, sum_g, count_oversize = 0, 0, 0, 0
+for i = 1, #flat, 2 do
+  local c, m, g, k = string.match(flat[i + 1], '([^|]*)|([^|]*)|([^|]*)|([^|]*)')
+  if k == 'oversize' then
+    count_oversize = count_oversize + 1
+  else
+    sum_c = sum_c + tonumber(c); sum_m = sum_m + tonumber(m); sum_g = sum_g + tonumber(g)
+  end
+end
+local admit = false
+if kind == 'oversize' then
+  if count_oversize < max_oversize and (reserve == 0 or (sum_c == 0 and sum_m == 0 and sum_g == 0)) then
+    admit = true
+  end
+else
+  local fits = (bc < 0 or sum_c + rc <= bc) and (bm < 0 or sum_m + rm <= bm) and (bg < 0 or sum_g + rg <= bg)
+  if fits and (reserve == 0 or count_oversize == 0) then admit = true end
+end
+if admit then
+  redis.call('HSET', key, job_id, rc .. '|' .. rm .. '|' .. rg .. '|' .. kind)
+end
+if ttl > 0 and redis.call('EXISTS', key) == 1 then redis.call('EXPIRE', key, ttl) end
+if admit then return 1 else return 0 end
+"""
+
+
+class ValkeyAllocationStore(AllocationStore):
+    """Valkey/Redis-backed store. redis-py speaks the Valkey wire protocol.
+
+    Keys are ``{key_prefix}:{pool}:user:{{user_id}}`` -- the ``{user_id}`` hash tag co-locates
+    a user's pool keys on one cluster slot. Each ledger is a hash of
+    ``job_id -> "cores|mem|gpus|kind"`` with a whole-key TTL as the orphan backstop.
+    """
+
+    def __init__(
+        self,
+        url: str = "valkey://localhost:6379/0",
+        key_prefix: str = "tpv:pool",
+        ttl: int = 3600,
+        client: Any = None,
+        **client_options: Any,
+    ):
+        try:
+            import redis
+        except ImportError as e:  # pragma: no cover - exercised only without redis installed
+            raise StoreUnavailable("The 'redis' package is required for ValkeyAllocationStore") from e
+        self._redis_mod = redis
+        if client is not None:
+            # Allow injecting a pre-built client (e.g. a fake) for tests / custom wiring.
+            self.client = client
+        else:
+            # redis-py understands redis:// and rediss://; normalise the valkey:// alias.
+            if url.startswith("valkey://"):
+                url = "redis://" + url[len("valkey://") :]
+            elif url.startswith("valkeys://"):
+                url = "rediss://" + url[len("valkeys://") :]
+            self.client = redis.from_url(url, decode_responses=True, **client_options)
+        self.key_prefix = key_prefix
+        self.ttl = ttl
+        self._admit = self.client.register_script(_ADMIT_LUA)
+
+    def _key(self, pool: str, user_id: int) -> str:
+        return f"{self.key_prefix}:{pool}:user:{{{user_id}}}"
+
+    def read(self, pool: str, user_id: int) -> dict[int, tuple[ResourceUsage, str]]:
+        try:
+            raw = self.client.hgetall(self._key(pool, user_id))
+        except self._redis_mod.exceptions.RedisError as e:
+            raise StoreUnavailable(str(e)) from e
+        ledger = {}
+        for jid, val in raw.items():
+            c, m, g, kind = val.split("|")
+            ledger[int(jid)] = (ResourceUsage(float(c), float(m), float(g)), kind)
+        return ledger
+
+    def admit(
+        self,
+        pool: str,
+        user_id: int,
+        job_id: int,
+        req: ResourceUsage,
+        *,
+        kind: str,
+        budget: Budget,
+        max_oversize: int,
+        reserve_pool: bool,
+        drop_job_ids: set[int],
+    ) -> bool:
+        args = [
+            job_id,
+            req.cores,
+            req.mem,
+            req.gpus,
+            kind,
+            -1 if budget.cores is None else budget.cores,
+            -1 if budget.mem is None else budget.mem,
+            -1 if budget.gpus is None else budget.gpus,
+            max_oversize,
+            1 if reserve_pool else 0,
+            self.ttl,
+            *drop_job_ids,
+        ]
+        try:
+            return bool(self._admit(keys=[self._key(pool, user_id)], args=args))
+        except self._redis_mod.exceptions.RedisError as e:
+            raise StoreUnavailable(str(e)) from e
+
+
+class ResourcePoolManager:
+    """Instantiates and holds the pluggable store and budget provider for a loaded config.
+
+    One is created per mapper (see :class:`tpv.core.mapper.EntityToDestinationMapper`).
+    """
+
+    def __init__(self, config: ResourcePoolConfig):
+        self.config = config
+        self.store: AllocationStore = _load_class(config.store)(**(config.store_options or {}))
+        self.provider: BudgetProvider = _load_class(config.budget_provider)(config)
+
+    def pool(self, name: str) -> Pool | None:
+        return self.config.pools.get(name)
+
+
+def terminal_job_ids(sa_session: scoped_session[Session], job_ids: set[int]) -> set[int]:
+    """Return the subset of ``job_ids`` whose Galaxy job has reached a terminal state.
+
+    Takes the SQLAlchemy session (``app.model.context``) rather than the whole ``app`` so it
+    depends only on what it uses. Read-only; absent/unknown job rows are *not* returned (kept
+    in the ledger), so allocations are released only on positive evidence of completion.
+    """
+    if not job_ids:
+        return set()
+    rows = (
+        sa_session.query(model.Job.id)
+        .filter(model.Job.table.c.id.in_(list(job_ids)))
+        .filter(model.Job.table.c.state.in_(TERMINAL_JOB_STATES))
+    )
+    return {row[0] for row in rows}

--- a/tpv/core/resource_pool.py
+++ b/tpv/core/resource_pool.py
@@ -14,8 +14,8 @@ TPV never needs a job-completion callback.
 
 The load-bearing operation is :meth:`AllocationStore.admit_many`, a single atomic
 check-and-record: it drops finished jobs, sums the remaining committed usage and, if the
-incoming job fits every matching pool budget (or oversize allowance), records it in all pools. Because it is atomic,
-two concurrent maps for the same user cannot both squeak past the budget.
+incoming job fits every matching pool budget (or oversize allowance), records it in all pools.
+Because it is atomic, two concurrent maps for the same user cannot both exceed the budget.
 """
 
 from __future__ import annotations
@@ -84,16 +84,17 @@ class Budget(NamedTuple):
 class OversizePolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    # How many over-budget jobs a user may run concurrently in this pool. 0 (the default)
-    # means over-budget jobs are rejected outright -- the correct setting for UDT pools.
-    max_concurrent: int = 0
-    # Optional absolute ceiling; a job requesting more than this always fails, even within
-    # the oversize allowance.
-    hard_max_cores: float | None = None
-    hard_max_mem: float | None = None
-    hard_max_gpus: float | None = None
-    # When true, a pool holds either normal jobs or a single oversize job, never both.
-    reserve_pool: bool = False
+    max_concurrent: int = Field(
+        default=0,
+        description="Maximum concurrent oversize jobs per user in this pool; 0 rejects oversize requests.",
+    )
+    hard_max_cores: float | None = Field(default=None, description="Maximum cores requested by one oversize job.")
+    hard_max_mem: float | None = Field(default=None, description="Maximum memory in GB requested by one oversize job.")
+    hard_max_gpus: float | None = Field(default=None, description="Maximum GPUs requested by one oversize job.")
+    reserve_pool: bool = Field(
+        default=False,
+        description="Prevent normal and oversize resource usage from coexisting in this pool; max_concurrent still applies.",
+    )
 
 
 class StoreConfig(BaseModel):

--- a/tpv/core/resource_pool.py
+++ b/tpv/core/resource_pool.py
@@ -372,8 +372,8 @@ class ResourcePoolManager:
     mapper (see :class:`tpv.core.mapper.EntityToDestinationMapper`).
     """
 
-    def __init__(self, store_config: StoreConfig):
-        self.store: AllocationStore = store_config.build_store()
+    def __init__(self, store: AllocationStore):
+        self.store: AllocationStore = store
 
 
 def terminal_job_ids(sa_session: scoped_session[Session], job_ids: set[int]) -> set[int]:

--- a/tpv/core/resource_pool.py
+++ b/tpv/core/resource_pool.py
@@ -12,15 +12,16 @@ the jobs TPV has admitted to the pool. Galaxy's job table is consulted read-only
 which ledgered jobs have reached a terminal state so their allocation can be released --
 TPV never needs a job-completion callback.
 
-The load-bearing operation is :meth:`AllocationStore.admit`, a single atomic
+The load-bearing operation is :meth:`AllocationStore.admit_many`, a single atomic
 check-and-record: it drops finished jobs, sums the remaining committed usage and, if the
-incoming job fits the budget (or the oversize allowance), records it. Because it is atomic,
+incoming job fits every matching pool budget (or oversize allowance), records it in all pools. Because it is atomic,
 two concurrent maps for the same user cannot both squeak past the budget.
 """
 
 from __future__ import annotations
 
 import importlib
+import json
 import logging
 import threading
 from abc import ABC, abstractmethod
@@ -158,6 +159,16 @@ def _decide(
     return fits
 
 
+class PoolAdmission(NamedTuple):
+    pool: str
+    req: ResourceUsage
+    kind: str
+    budget: Budget
+    max_oversize: int
+    reserve_pool: bool
+    drop_job_ids: set[int]
+
+
 class AllocationStore(ABC):
     """Holds, per ``(pool, user)``, the ledger of admitted ``{job_id: allocation}``."""
 
@@ -166,6 +177,14 @@ class AllocationStore(ABC):
         """Return the current ledger as ``{job_id: (allocation, kind)}``."""
 
     @abstractmethod
+    def admit_many(self, user_id: int, job_id: int, admissions: list[PoolAdmission]) -> bool:
+        """Atomically reconcile and admit a job to every requested pool, or none.
+
+        Drop terminal IDs and the job's own previous entry from every requested pool first.
+        On rejection those drops remain, but no new allocation is recorded in any pool.
+        Each pool must appear at most once; all pools must belong to the same user.
+        """
+
     def admit(
         self,
         pool: str,
@@ -179,14 +198,19 @@ class AllocationStore(ABC):
         reserve_pool: bool,
         drop_job_ids: set[int],
     ) -> bool:
-        """Atomically drop ``drop_job_ids`` (and ``job_id``'s own stale entry), then admit
-        ``job_id`` iff it fits. Returns True (admitted, entry recorded) or False (deferred,
-        ledger otherwise left as-is apart from the drops)."""
+        """Admit to a single pool with the same atomic semantics as ``admit_many``."""
+        return self.admit_many(
+            user_id,
+            job_id,
+            [PoolAdmission(pool, req, kind, budget, max_oversize, reserve_pool, drop_job_ids)],
+        )
 
 
 class InMemoryAllocationStore(AllocationStore):
-    """Process-local store for tests and single-process deployments. Atomicity is provided by
-    a lock; it deliberately mirrors :class:`ValkeyAllocationStore`'s semantics."""
+    """Process-local store for tests and single-process deployments.
+
+    A lock covers all of a job's pools, mirroring the Valkey script's atomic admission.
+    """
 
     def __init__(self, key_prefix: str = "tpv:pool", **_ignored: Any):
         self.key_prefix = key_prefix
@@ -200,69 +224,62 @@ class InMemoryAllocationStore(AllocationStore):
         with self._lock:
             return dict(self._data.get(self._key(pool, user_id), {}))
 
-    def admit(
-        self,
-        pool: str,
-        user_id: int,
-        job_id: int,
-        req: ResourceUsage,
-        *,
-        kind: str,
-        budget: Budget,
-        max_oversize: int,
-        reserve_pool: bool,
-        drop_job_ids: set[int],
-    ) -> bool:
-        key = self._key(pool, user_id)
+    def admit_many(self, user_id: int, job_id: int, admissions: list[PoolAdmission]) -> bool:
         with self._lock:
-            ledger = self._data.setdefault(key, {})
-            for jid in drop_job_ids:
-                ledger.pop(jid, None)
-            ledger.pop(job_id, None)
-            if _decide(ledger, req, kind, budget, max_oversize, reserve_pool):
-                ledger[job_id] = (req, kind)
-                return True
-            return False
+            ledgers = [self._data.setdefault(self._key(a.pool, user_id), {}) for a in admissions]
+            for admission, ledger in zip(admissions, ledgers):
+                for jid in admission.drop_job_ids | {job_id}:
+                    ledger.pop(jid, None)
+            if not all(
+                _decide(ledger, a.req, a.kind, a.budget, a.max_oversize, a.reserve_pool)
+                for a, ledger in zip(admissions, ledgers)
+            ):
+                return False
+            for admission, ledger in zip(admissions, ledgers):
+                ledger[job_id] = (admission.req, admission.kind)
+            return True
 
 
-# Atomic admit for Valkey/Redis. Mirrors _decide(). KEYS[1] is the ledger key; ARGV is
-# [job_id, rc, rm, rg, kind, bc, bm, bg, max_oversize, reserve, drop_id...] where a
-# budget of -1 means "unlimited" for that dimension.
+# All keys use the same user hash tag, so this transaction also fits one Redis Cluster slot.
+# ARGV[1] is the job ID; ARGV[2] is a JSON array of policies in KEYS order. Budgets use -1
+# for unlimited dimensions. Job IDs inside the JSON remain strings to avoid Lua precision loss.
 _ADMIT_LUA = """
-local key = KEYS[1]
 local job_id = ARGV[1]
-local rc, rm, rg = tonumber(ARGV[2]), tonumber(ARGV[3]), tonumber(ARGV[4])
-local kind = ARGV[5]
-local bc, bm, bg = tonumber(ARGV[6]), tonumber(ARGV[7]), tonumber(ARGV[8])
-local max_oversize = tonumber(ARGV[9])
-local reserve = tonumber(ARGV[10])
-redis.call('HDEL', key, job_id)
-for i = 11, #ARGV do redis.call('HDEL', key, ARGV[i]) end
-local flat = redis.call('HGETALL', key)
-local sum_c, sum_m, sum_g, count_oversize = 0, 0, 0, 0
-for i = 1, #flat, 2 do
-  local c, m, g, k = string.match(flat[i + 1], '([^|]*)|([^|]*)|([^|]*)|([^|]*)')
-  if k == 'oversize' then
-    count_oversize = count_oversize + 1
+local admissions = cjson.decode(ARGV[2])
+for i, key in ipairs(KEYS) do
+  redis.call('HDEL', key, job_id)
+  for _, jid in ipairs(admissions[i].drop_job_ids) do redis.call('HDEL', key, jid) end
+  -- Live jobs may outlast any idle interval; remove TTLs left by older TPV versions.
+  redis.call('PERSIST', key)
+end
+for i, key in ipairs(KEYS) do
+  local a = admissions[i]
+  local flat = redis.call('HGETALL', key)
+  local sum_c, sum_m, sum_g, count_oversize = 0, 0, 0, 0
+  for j = 1, #flat, 2 do
+    local c, m, g, kind = string.match(flat[j + 1], '([^|]*)|([^|]*)|([^|]*)|([^|]*)')
+    if kind == 'oversize' then
+      count_oversize = count_oversize + 1
+    else
+      sum_c = sum_c + tonumber(c); sum_m = sum_m + tonumber(m); sum_g = sum_g + tonumber(g)
+    end
+  end
+  if a.kind == 'oversize' then
+    if count_oversize >= a.max_oversize then return 0 end
+    if a.reserve_pool and (sum_c ~= 0 or sum_m ~= 0 or sum_g ~= 0) then return 0 end
   else
-    sum_c = sum_c + tonumber(c); sum_m = sum_m + tonumber(m); sum_g = sum_g + tonumber(g)
+    local fits = (a.bc < 0 or sum_c + a.rc <= a.bc)
+      and (a.bm < 0 or sum_m + a.rm <= a.bm)
+      and (a.bg < 0 or sum_g + a.rg <= a.bg)
+    if not fits or (a.reserve_pool and count_oversize > 0) then return 0 end
   end
 end
-local admit = false
-if kind == 'oversize' then
-  if count_oversize < max_oversize and (reserve == 0 or (sum_c == 0 and sum_m == 0 and sum_g == 0)) then
-    admit = true
-  end
-else
-  local fits = (bc < 0 or sum_c + rc <= bc) and (bm < 0 or sum_m + rm <= bm) and (bg < 0 or sum_g + rg <= bg)
-  if fits and (reserve == 0 or count_oversize == 0) then admit = true end
+-- Only write allocations after every pool has accepted the job.
+for i, key in ipairs(KEYS) do
+  local a = admissions[i]
+  redis.call('HSET', key, job_id, a.rc .. '|' .. a.rm .. '|' .. a.rg .. '|' .. a.kind)
 end
-if admit then
-  redis.call('HSET', key, job_id, rc .. '|' .. rm .. '|' .. rg .. '|' .. kind)
-end
--- Live jobs may outlast any idle interval; also remove TTLs left by older TPV versions.
-redis.call('PERSIST', key)
-if admit then return 1 else return 0 end
+return 1
 """
 
 
@@ -317,34 +334,31 @@ class ValkeyAllocationStore(AllocationStore):
             ledger[int(jid)] = (ResourceUsage(float(c), float(m), float(g)), kind)
         return ledger
 
-    def admit(
-        self,
-        pool: str,
-        user_id: int,
-        job_id: int,
-        req: ResourceUsage,
-        *,
-        kind: str,
-        budget: Budget,
-        max_oversize: int,
-        reserve_pool: bool,
-        drop_job_ids: set[int],
-    ) -> bool:
-        args = [
-            job_id,
-            req.cores,
-            req.mem,
-            req.gpus,
-            kind,
-            -1 if budget.cores is None else budget.cores,
-            -1 if budget.mem is None else budget.mem,
-            -1 if budget.gpus is None else budget.gpus,
-            max_oversize,
-            1 if reserve_pool else 0,
-            *drop_job_ids,
+    def admit_many(self, user_id: int, job_id: int, admissions: list[PoolAdmission]) -> bool:
+        if not admissions:
+            return True
+        policies = [
+            {
+                "rc": a.req.cores,
+                "rm": a.req.mem,
+                "rg": a.req.gpus,
+                "kind": a.kind,
+                "bc": -1 if a.budget.cores is None else a.budget.cores,
+                "bm": -1 if a.budget.mem is None else a.budget.mem,
+                "bg": -1 if a.budget.gpus is None else a.budget.gpus,
+                "max_oversize": a.max_oversize,
+                "reserve_pool": a.reserve_pool,
+                "drop_job_ids": [str(jid) for jid in a.drop_job_ids],
+            }
+            for a in admissions
         ]
         try:
-            return bool(self._admit(keys=[self._key(pool, user_id)], args=args))
+            return bool(
+                self._admit(
+                    keys=[self._key(a.pool, user_id) for a in admissions],
+                    args=[job_id, json.dumps(policies)],
+                )
+            )
         except self._redis_mod.exceptions.RedisError as e:
             raise StoreUnavailable(str(e)) from e
 

--- a/tpv/core/resource_pool.py
+++ b/tpv/core/resource_pool.py
@@ -98,16 +98,15 @@ class OversizePolicy(BaseModel):
 class StoreConfig(BaseModel):
     """Infrastructure wiring for the allocation store, declared under
     ``global.resource_pool_store``. Only backend wiring belongs here -- a store class plus its
-    options (url, ttl, key_prefix, ...); pool *policy* is expressed as ``pools:`` entities::
+    options (url, key_prefix, ...); pool *policy* is expressed as ``pools:`` entities::
 
         global:
           resource_pool_store:
             class: tpv.core.resource_pool.ValkeyAllocationStore
             url: valkey://localhost:6379/0
-            ttl: 3600
     """
 
-    # Extra keys (url, ttl, key_prefix, ...) are collected and passed to the store constructor.
+    # Extra keys (url, key_prefix, ...) are collected and passed to the store constructor.
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     store_class: str = Field(alias="class", default="tpv.core.resource_pool.ValkeyAllocationStore")
@@ -187,7 +186,7 @@ class AllocationStore(ABC):
 
 class InMemoryAllocationStore(AllocationStore):
     """Process-local store for tests and single-process deployments. Atomicity is provided by
-    a lock; it deliberately mirrors :class:`ValkeyAllocationStore`'s semantics (minus TTL)."""
+    a lock; it deliberately mirrors :class:`ValkeyAllocationStore`'s semantics."""
 
     def __init__(self, key_prefix: str = "tpv:pool", **_ignored: Any):
         self.key_prefix = key_prefix
@@ -227,7 +226,7 @@ class InMemoryAllocationStore(AllocationStore):
 
 
 # Atomic admit for Valkey/Redis. Mirrors _decide(). KEYS[1] is the ledger key; ARGV is
-# [job_id, rc, rm, rg, kind, bc, bm, bg, max_oversize, reserve, ttl, drop_id...] where a
+# [job_id, rc, rm, rg, kind, bc, bm, bg, max_oversize, reserve, drop_id...] where a
 # budget of -1 means "unlimited" for that dimension.
 _ADMIT_LUA = """
 local key = KEYS[1]
@@ -237,9 +236,8 @@ local kind = ARGV[5]
 local bc, bm, bg = tonumber(ARGV[6]), tonumber(ARGV[7]), tonumber(ARGV[8])
 local max_oversize = tonumber(ARGV[9])
 local reserve = tonumber(ARGV[10])
-local ttl = tonumber(ARGV[11])
 redis.call('HDEL', key, job_id)
-for i = 12, #ARGV do redis.call('HDEL', key, ARGV[i]) end
+for i = 11, #ARGV do redis.call('HDEL', key, ARGV[i]) end
 local flat = redis.call('HGETALL', key)
 local sum_c, sum_m, sum_g, count_oversize = 0, 0, 0, 0
 for i = 1, #flat, 2 do
@@ -262,7 +260,8 @@ end
 if admit then
   redis.call('HSET', key, job_id, rc .. '|' .. rm .. '|' .. rg .. '|' .. kind)
 end
-if ttl > 0 and redis.call('EXISTS', key) == 1 then redis.call('EXPIRE', key, ttl) end
+-- Live jobs may outlast any idle interval; also remove TTLs left by older TPV versions.
+redis.call('PERSIST', key)
 if admit then return 1 else return 0 end
 """
 
@@ -272,17 +271,20 @@ class ValkeyAllocationStore(AllocationStore):
 
     Keys are ``{key_prefix}:{pool}:user:{{user_id}}`` -- the ``{user_id}`` hash tag co-locates
     a user's pool keys on one cluster slot. Each ledger is a hash of
-    ``job_id -> "cores|mem|gpus|kind"`` with a whole-key TTL as the orphan backstop.
+    ``job_id -> "cores|mem|gpus|kind"``. Entries persist until job-state reconciliation
+    confirms completion; an idle ledger can still belong to running jobs.
     """
 
     def __init__(
         self,
         url: str = "valkey://localhost:6379/0",
         key_prefix: str = "tpv:pool",
-        ttl: int = 3600,
+        ttl: int = 0,
         client: Any = None,
         **client_options: Any,
     ):
+        if ttl != 0:
+            raise ValueError("Resource pool ledgers cannot expire while jobs are running; remove ttl or set ttl: 0")
         try:
             import redis
         except ImportError as e:  # pragma: no cover - exercised only without redis installed
@@ -299,7 +301,6 @@ class ValkeyAllocationStore(AllocationStore):
                 url = "rediss://" + url[len("valkeys://") :]
             self.client = redis.from_url(url, decode_responses=True, **client_options)
         self.key_prefix = key_prefix
-        self.ttl = ttl
         self._admit = self.client.register_script(_ADMIT_LUA)
 
     def _key(self, pool: str, user_id: int) -> str:
@@ -340,7 +341,6 @@ class ValkeyAllocationStore(AllocationStore):
             -1 if budget.gpus is None else budget.gpus,
             max_oversize,
             1 if reserve_pool else 0,
-            self.ttl,
             *drop_job_ids,
         ]
         try:

--- a/tpv/rules/gateway.py
+++ b/tpv/rules/gateway.py
@@ -16,6 +16,7 @@ from galaxy.util.watcher import get_watcher
 from tpv.core.explain import ExplainCollector, ExplainPhase
 from tpv.core.loader import TPVConfigLoader
 from tpv.core.mapper import EntityToDestinationMapper
+from tpv.core.resource_pool import AllocationStore
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +28,9 @@ WATCHERS_BY_CONFIG_FILE: dict[str, Any] = {}
 REFERRERS_BY_CONFIG_FILE: dict[str, dict[str, JOB_YAML_CONFIG_TYPE]] = defaultdict(dict)
 
 
-def load_destination_mapper(tpv_configs: JOB_YAML_CONFIG_TYPE, reload: bool = False) -> EntityToDestinationMapper:
+def load_destination_mapper(
+    tpv_configs: JOB_YAML_CONFIG_TYPE, reload: bool = False, resource_pool_store: AllocationStore | None = None
+) -> EntityToDestinationMapper:
     tpv_config_list: list[Any] = listify(tpv_configs)
     log.info(f"{'re' if reload else ''}loading tpv rules from: {tpv_configs}")
     loader = None
@@ -38,7 +41,7 @@ def load_destination_mapper(tpv_configs: JOB_YAML_CONFIG_TYPE, reload: bool = Fa
             # it is a raw config already
             current_loader = TPVConfigLoader(tpv_config, parent=loader)
         loader = current_loader
-    return EntityToDestinationMapper(loader)  # type: ignore
+    return EntityToDestinationMapper(loader, resource_pool_store=resource_pool_store)  # type: ignore
 
 
 def setup_destination_mapper(


### PR DESCRIPTION
Add per-user budgets for the aggregate cores, memory, and GPUs held by active jobs. These complement Galaxy's job-count concurrency limits and support use cases including User Defined Tools (galaxyproject/usegalaxy-playbook#467).

Pools are first-class entities under top-level `pools:`; backend wiring lives under `global.resource_pool_store`. User and role `max_concurrent_*` fields override pool defaults through the entity pipeline. Pool `require`/`reject` selectors match positive job tags without allowing unrelated routing requirements to bypass enforcement. Abstract pools provide reusable policy, and children preserve omitted nested oversize settings.

A pluggable Valkey or in-memory store admits all matching pools atomically after destination evaluation succeeds. Accounting uses the request captured before destination clamping. Ledgers do not expire while jobs may still be running; reconciliation against Galaxy's job states releases finished allocations. An optional oversize policy limits concurrent oversize jobs and their individual resource requests. Store outages defer jobs by default, with explicit per-pool `fail_open` support.

Validation: 300 tests passed, including slow Galaxy resubmission tests; memory/Valkey Lua parity and concurrent admission tests; mypy; Black and isort.

The documentation explains persistent-store requirements, oversize semantics, and the existing Galaxy ready-window limitation: a backlog of deferred jobs can hide later eligible jobs, and increasing the window is only a mitigation (usegalaxy-au/infrastructure#2254).
