### PR TITLE
Add helpers for per-param and compression-adjusted input sizes

### DIFF
--- a/docs/topics/advanced_topics.rst
+++ b/docs/topics/advanced_topics.rst
@@ -124,6 +124,69 @@ be used)
 +--------------------+---------------+----------------------+
 
 
+Input sizes
+===========
+
+Resource requirements are commonly calculated from the size of a job's inputs. The `input_size` context variable
+provides the total size in gigabytes of all of a job's inputs, and the `helpers.get_input_size` function provides
+more control over how that total is arrived at, as introduced in :doc:`tpv_by_example`.
+
+Arguments
+---------
+
+`get_input_size` returns a size in gigabytes, and accepts the following arguments:
+
++----------------------------+----------------------------------------------------------------------------+
+| Argument                   | Description                                                                |
++============================+============================================================================+
+| job                        | the job being mapped, available as a context variable in all expressions   |
++----------------------------+----------------------------------------------------------------------------+
+| param_name                 | the tool parameter to size. If omitted, all inputs are totalled            |
++----------------------------+----------------------------------------------------------------------------+
+| estimate_uncompressed_size | whether to scale compressed inputs by compression_factor. True by default  |
++----------------------------+----------------------------------------------------------------------------+
+| compression_factor         | the multiplier applied to compressed inputs. 3.4 by default                |
++----------------------------+----------------------------------------------------------------------------+
+
+An input is considered compressed if its datatype extension ends in `.gz` or `.bz2`, as `fastqsanger.gz` does.
+Since a compressed dataset's recorded size is its size on disk, and resource estimates generally need to be based
+on the size the tool will actually process, compressed inputs are scaled up by `compression_factor` unless
+`estimate_uncompressed_size` is set to False.
+
+Naming and matching parameters
+------------------------------
+
+`param_name` is the fully prefixed parameter name, so a parameter named `input_1` within a conditional named
+`library` is addressed as `library|input_1`.
+
+Galaxy does not record data parameters against a job as a single value per parameter. A parameter that accepts
+multiple datasets, and a dataset collection parameter, are both flattened into one entry per dataset, named
+`library|input_11`, `library|input_12` and so on. `get_input_size` matches all of the entries belonging to the
+named parameter, and counts each dataset only once, so the same expression can be used whether the datasets were
+selected individually or supplied as a collection.
+
+A parameter that has no datasets recorded against it, such as an unset optional parameter, or one belonging to a
+branch of a conditional that was not selected, contributes a size of zero rather than raising an error. Several
+parameters can therefore be totalled without testing which of them are in use. For example, the hisat2 tool holds
+its reads in a conditional with separate branches for single end, paired end and paired collection inputs, all of
+which can be accommodated with a single expression:
+
+.. code-block:: yaml
+   :linenos:
+
+   tools:
+     toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/.*:
+       cores: 4
+       mem: |
+         reads = helpers.get_input_size(job, "library|input_1") + helpers.get_input_size(job, "library|input_2")
+         min(max(int(reads * 4), 8), 128)
+
+Here, `library|input_2` is only present for paired end inputs, and contributes nothing otherwise, while
+`library|input_1` covers the reads of all three branches, including both members of a paired collection.
+
+Note that a tool with parameters named such that one is the other followed by a number, `input` and `input1` for
+example, cannot be addressed unambiguously, as a request for `input` will also match the datasets of `input1`.
+
 Scheduling
 ==========
 

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -260,6 +260,31 @@ are evaluated as python code blocks, while string variables are evaluated as pyt
 The execute block can be used to create arbitrary side-effects if a rule matches. The return value of an execute
 block is ignored.
 
+Input sizes
+-----------
+
+The automatically available `input_size` variable totals the sizes of all of a job's inputs, but rules often need
+finer control, such as the size of one particular input. Resource estimates that depend on input size, memory in
+particular, also typically need to be calculated from the uncompressed size of the input, whereas the size
+recorded for a compressed dataset is its size on disk. The `helpers.get_input_size` function provides both.
+
+.. code-block:: yaml
+   :linenos:
+
+   tools:
+     toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/.*:
+       cores: 4
+       mem: min(max(int(helpers.get_input_size(job, "library|input_1") * 4), 8), 128)
+
+In this example, only the reads input of the hisat2 tool is sized, ignoring any other inputs the job may have, and
+the tool is allocated 4GB of memory per gigabyte of reads, clamped to between 8GB and 128GB. Since the reads are
+typically compressed, and the estimate must be based on their uncompressed size, their recorded size is first
+multiplied by 3.4.
+
+Omitting the parameter name totals all of the job's inputs instead, exactly as the `input_size` variable does.
+The compression factor and the remaining arguments, along with the rules for naming and matching parameters, are
+described in :doc:`advanced_topics`.
+
 User and Role Handling
 ------------------------
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,14 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from tpv.commands.test import mock_galaxy
-from tpv.core.helpers import get_dataset_attributes, weighted_random_sampling
+from tpv.core.helpers import (
+    get_dataset_attributes,
+    get_input_dataset,
+    get_input_datasets,
+    get_input_size,
+    input_size,
+    weighted_random_sampling,
+)
 
 
 class TestHelpers(unittest.TestCase):
@@ -14,15 +21,112 @@ class TestHelpers(unittest.TestCase):
     def test_get_dataset_attributes(self):
         """Test that the function returns a dictionary with the correct attributes"""
         job = mock_galaxy.Job()
+        dataset = mock_galaxy.Dataset("test.txt", file_size=7 * 1024**3, object_store_id="files1")
+        job.add_input_dataset(mock_galaxy.DatasetAssociation("test", dataset))
+        dataset_attributes = get_dataset_attributes(job.input_datasets)
+        expected_result = {dataset.id: {"object_store_id": "files1", "size": 7 * 1024**3}}
+        self.assertEqual(dataset_attributes, expected_result)
+
+    @staticmethod
+    def _job_with_multiple_data_param():
+        """A job with a `multiple="true"` data param `inputs` holding two datasets.
+
+        Galaxy records the first dataset twice: once as `inputs` (the copy-metadata alias for
+        the first element) and once as `inputs1`.
+        """
+        job = mock_galaxy.Job()
+        first = mock_galaxy.DatasetAssociation(
+            "first", mock_galaxy.Dataset("first.txt", file_size=3 * 1024**3), extension="txt"
+        )
+        second = mock_galaxy.DatasetAssociation(
+            "second", mock_galaxy.Dataset("second.txt", file_size=5 * 1024**3), extension="txt"
+        )
+        job.add_input_dataset(first, name="inputs")
+        job.add_input_dataset(first, name="inputs1")
+        job.add_input_dataset(second, name="inputs2")
+        return job
+
+    def test_get_input_datasets_deduplicates_multiple_data_param_alias(self):
+        """The `name`/`name1` alias of a multiple data param must not yield the dataset twice"""
+        job = self._job_with_multiple_data_param()
+        datasets = get_input_datasets(job, "inputs")
+        self.assertEqual([dataset.name for dataset in datasets], ["first", "second"])
+
+    def test_get_input_datasets_matches_collection_element_names(self):
+        """A collection param is recorded as `name1`..`nameN`, with no unsuffixed entry"""
+        job = mock_galaxy.Job()
+        for index in range(1, 4):
+            job.add_input_dataset(
+                mock_galaxy.DatasetAssociation(
+                    f"element{index}", mock_galaxy.Dataset(f"element{index}.txt", file_size=1 * 1024**3)
+                ),
+                name=f"inputs{index}",
+            )
+        datasets = get_input_datasets(job, "inputs")
+        self.assertEqual([dataset.name for dataset in datasets], ["element1", "element2", "element3"])
+
+    def test_get_input_datasets_ignores_other_params(self):
+        """Only datasets recorded for the requested param are returned"""
+        job = self._job_with_multiple_data_param()
+        job.add_input_dataset(
+            mock_galaxy.DatasetAssociation("ref", mock_galaxy.Dataset("ref.txt", file_size=9 * 1024**3)),
+            name="reference",
+        )
+        self.assertEqual([dataset.name for dataset in get_input_datasets(job, "reference")], ["ref"])
+        self.assertEqual([dataset.name for dataset in get_input_datasets(job, "inputs")], ["first", "second"])
+        self.assertEqual([dataset.name for dataset in get_input_datasets(job)], ["first", "second", "ref"])
+
+    def test_get_input_datasets_skips_unset_optional_params(self):
+        """An unset optional data param is recorded with no dataset at all"""
+        job = mock_galaxy.Job()
+        job.input_datasets.append(mock_galaxy.JobToInputDatasetAssociation("inputs", None))
+        self.assertEqual(get_input_datasets(job, "inputs"), [])
+        self.assertIsNone(get_input_dataset(job, "inputs"))
+        self.assertEqual(get_input_size(job, "inputs"), 0)
+
+    def test_get_input_dataset_returns_first_match(self):
+        job = self._job_with_multiple_data_param()
+        dataset = get_input_dataset(job, "inputs")
+        self.assertEqual(dataset.name, "first")
+        self.assertIsNone(get_input_dataset(job, "nonexistent"))
+
+    def test_get_input_size_totals_all_inputs_by_default(self):
+        job = self._job_with_multiple_data_param()
+        self.assertEqual(get_input_size(job), 8)
+        # the existing input_size helper deduplicates the same way
+        self.assertEqual(input_size(job), 8)
+
+    def test_get_input_size_by_param_name(self):
+        job = self._job_with_multiple_data_param()
+        job.add_input_dataset(
+            mock_galaxy.DatasetAssociation("ref", mock_galaxy.Dataset("ref.txt", file_size=9 * 1024**3)),
+            name="reference",
+        )
+        self.assertEqual(get_input_size(job, "inputs"), 8)
+        self.assertEqual(get_input_size(job, "reference"), 9)
+        self.assertEqual(get_input_size(job), 17)
+
+    def test_get_input_size_adjusts_compressed_inputs(self):
+        job = mock_galaxy.Job()
         job.add_input_dataset(
             mock_galaxy.DatasetAssociation(
-                "test",
-                mock_galaxy.Dataset("test.txt", file_size=7 * 1024**3, object_store_id="files1"),
-            )
+                "compressed",
+                mock_galaxy.Dataset("compressed.fastq.gz", file_size=2 * 1024**3),
+                extension="fastqsanger.gz",
+            ),
+            name="inputs1",
         )
-        dataset_attributes = get_dataset_attributes(job.input_datasets)
-        expected_result = {0: {"object_store_id": "files1", "size": 7 * 1024**3}}
-        self.assertEqual(dataset_attributes, expected_result)
+        job.add_input_dataset(
+            mock_galaxy.DatasetAssociation(
+                "uncompressed",
+                mock_galaxy.Dataset("uncompressed.fastq", file_size=4 * 1024**3),
+                extension="fastqsanger",
+            ),
+            name="inputs2",
+        )
+        self.assertAlmostEqual(get_input_size(job, "inputs"), 2 * 3.4 + 4)
+        self.assertAlmostEqual(get_input_size(job, "inputs", compression_factor=2), 2 * 2 + 4)
+        self.assertEqual(get_input_size(job, "inputs", estimate_uncompressed_size=False), 6)
 
     def test_weighted_random_sampling_without_weights_uses_unweighted_sampling(self):
         """When no destination defines params.weight, use unweighted random sampling."""

--- a/tpv/commands/test/mock_galaxy.py
+++ b/tpv/commands/test/mock_galaxy.py
@@ -1,4 +1,5 @@
 import hashlib
+import itertools
 from typing import Any, cast
 
 from galaxy.job_metrics import JobMetrics
@@ -64,11 +65,10 @@ class User:
 
 # Job mock and helpers=======================================
 class Dataset:
-    counter = 0
+    counter = itertools.count()
 
     def __init__(self, file_name: str, file_size: int, object_store_id: str | None = None):
-        self.id = self.counter
-        self.counter += 1
+        self.id = next(Dataset.counter)
         self.file_name = file_name
         self.file_size = file_size
         self.object_store_id = object_store_id
@@ -78,9 +78,10 @@ class Dataset:
 
 
 class DatasetAssociation:
-    def __init__(self, name: str, dataset: Dataset):
+    def __init__(self, name: str, dataset: Dataset, extension: str = "txt"):
         self.name = name
         self.dataset = dataset
+        self.extension = extension
 
 
 class JobToInputDatasetAssociation:
@@ -97,8 +98,10 @@ class Job:
         self.parameters: dict[str, Any] = {}
         self.history: History | None = None
 
-    def add_input_dataset(self, dataset_association: DatasetAssociation) -> None:
-        self.input_datasets.append(JobToInputDatasetAssociation(dataset_association.name, dataset_association))
+    def add_input_dataset(self, dataset_association: DatasetAssociation, name: str | None = None) -> None:
+        # `name` allows the association to be recorded under a different name than the dataset's,
+        # mirroring how Galaxy records e.g. a collection param as `name1`..`nameN`
+        self.input_datasets.append(JobToInputDatasetAssociation(name or dataset_association.name, dataset_association))
 
     def get_param_values(self, app: App) -> dict[str, Any]:
         return self.param_values

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -7,13 +7,14 @@ except ImportError:
 
 import operator
 import random
+import re
 from collections.abc import Callable
 from functools import reduce
 from typing import Any
 
 from galaxy import model
 from galaxy.app import UniverseApplication
-from galaxy.model import Dataset, Job, JobToInputDatasetAssociation
+from galaxy.model import Dataset, HistoryDatasetAssociation, Job, JobToInputDatasetAssociation
 from galaxy.model import User as GalaxyUser
 from galaxy.tools import Tool as GalaxyTool
 
@@ -21,6 +22,12 @@ from tpv.core.entities import Destination, Entity
 from tpv.core.resource_requirements import TPVResourceFieldName, extract_resource_requirements_from_tool
 
 GIGABYTES = 1024.0**3
+
+# Datatype extension suffixes that indicate a compressed dataset, e.g. `fastqsanger.gz`
+COMPRESSED_EXTENSION_SUFFIXES = (".gz", ".bz2")
+
+# Default multiplier applied to compressed input sizes to approximate their decompressed size
+DEFAULT_COMPRESSION_FACTOR = 3.4
 
 
 def get_dataset_size(dataset: Dataset) -> float:
@@ -45,6 +52,71 @@ def calculate_dataset_total(
 
 def input_size(job: Job) -> float:
     return calculate_dataset_total(job.input_datasets) / GIGABYTES
+
+
+def __unique_input_datasets(
+    datasets: list[JobToInputDatasetAssociation] | None,
+) -> dict[int, HistoryDatasetAssociation]:
+    # Galaxy records a `multiple="true"` data param under both `name` and `name1`, so the same
+    # dataset can be associated with a job more than once. Key on the underlying dataset to
+    # count each file only once, preserving the order the inputs were recorded in.
+    unique_datasets: dict[int, HistoryDatasetAssociation] = {}
+    for inp_ds in datasets or []:
+        if inp_ds.dataset and inp_ds.dataset.dataset:
+            unique_datasets.setdefault(inp_ds.dataset.dataset.id, inp_ds.dataset)
+    return unique_datasets
+
+
+def get_input_datasets(job: Job, param_name: str | None = None) -> list[HistoryDatasetAssociation]:
+    """
+    Return a job's input datasets, optionally restricted to a single tool parameter.
+
+    Galaxy flattens data params into `job.input_datasets` by name: a single data param is
+    recorded as `name`, a `multiple="true"` data param as `name`, `name1`..`nameN` (where
+    `name` is an alias for `name1`), and a collection param as `name1`..`nameN`, one entry per
+    dataset in the collection. Matching all of those, then deduplicating, yields each dataset
+    of the parameter exactly once regardless of how it was supplied.
+
+    Note that `param_name` is the fully prefixed parameter name, so a data param nested in a
+    conditional is addressed as e.g. `cond|input`.
+    """
+    datasets = job.input_datasets
+    if param_name is not None:
+        pattern = re.compile(rf"^{re.escape(param_name)}\d*$")
+        datasets = [inp_ds for inp_ds in datasets or [] if pattern.match(inp_ds.name or "")]
+    return list(__unique_input_datasets(datasets).values())
+
+
+def get_input_dataset(job: Job, param_name: str) -> HistoryDatasetAssociation | None:
+    """
+    Return the first input dataset recorded for a tool parameter, or None if the parameter has
+    no input dataset (an unset optional param, for example).
+    """
+    datasets = get_input_datasets(job, param_name)
+    return datasets[0] if datasets else None
+
+
+def get_input_size(
+    job: Job,
+    param_name: str | None = None,
+    estimate_uncompressed_size: bool = True,
+    compression_factor: float = DEFAULT_COMPRESSION_FACTOR,
+) -> float:
+    """
+    Return the total size in gigabytes of a job's input datasets.
+
+    If `param_name` is given, only the datasets recorded for that tool parameter are totalled,
+    otherwise all of the job's input datasets are. Compressed inputs are multiplied by
+    `compression_factor` to estimate their uncompressed size, unless
+    `estimate_uncompressed_size` is False.
+    """
+    total = 0.0
+    for dataset in get_input_datasets(job, param_name):
+        multiplier = 1.0
+        if estimate_uncompressed_size and (dataset.extension or "").endswith(COMPRESSED_EXTENSION_SUFFIXES):
+            multiplier = compression_factor
+        total += get_dataset_size(dataset.dataset) * multiplier
+    return total / GIGABYTES
 
 
 def weighted_random_sampling(destinations: list[Destination]) -> list[Destination]:

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -44,7 +44,11 @@ def calculate_dataset_total(
     datasets: list[JobToInputDatasetAssociation] | None,
 ) -> float:
     if datasets:
-        unique_datasets = {inp_ds.dataset.dataset.id: inp_ds.dataset.dataset for inp_ds in datasets if inp_ds.dataset}
+        unique_datasets = {
+            inp_ds.dataset.dataset.id: inp_ds.dataset.dataset
+            for inp_ds in datasets
+            if inp_ds.dataset and inp_ds.dataset.dataset
+        }
         return reduce(sum_total, map(get_dataset_size, unique_datasets.values()), 0.0)
     else:
         return 0.0
@@ -241,5 +245,5 @@ def get_dataset_attributes(
             "size": get_dataset_size(i.dataset.dataset),
         }
         for i in datasets or {}
-        if i.dataset
+        if i.dataset and i.dataset.dataset
     }

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -112,6 +112,8 @@ def get_input_size(
     """
     total = 0.0
     for dataset in get_input_datasets(job, param_name):
+        if not dataset.dataset:
+            continue
         multiplier = 1.0
         if estimate_uncompressed_size and (dataset.extension or "").endswith(COMPRESSED_EXTENSION_SUFFIXES):
             multiplier = compression_factor


### PR DESCRIPTION
Particularly the `get_input_size()` helper replaces a ton of duplication I do in my rules to grab input sizes by param name and multiply by a factor when they're compressed.