### PR TITLE
Convert Galaxy tool RAM requirements from MiB to GiB

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,10 +5,14 @@
 TotalPerspectiveVortex (TPV) is a plugin for the `Galaxy application`_ that can route
 entities (Tools, Users, Roles) to appropriate destinations with appropriate resource
 alloations (cores, gpus, memory), based on a configurable yaml file. For example, it could
-allocate 8 cores and 32GB of RAM to a bwa-mem job, and route it to a Slurm cluster, while
-allocating 2 cores and 4GB of RAM to an upload job, and route it to a local runner. These
+allocate 8 cores and 32GiB of RAM to a bwa-mem job, and route it to a Slurm cluster, while
+allocating 2 cores and 4GiB of RAM to an upload job, and route it to a local runner. These
 rules can also be shared community-wide, imported at runtime by any Galaxy deployment, and
 overridden locally when necessary.
+
+Memory resources (``mem``, ``min_mem``, ``max_mem``, ``min_accepted_mem``, and
+``max_accepted_mem``) and input dataset sizes are expressed in gibibytes (GiB), where
+1 GiB = 1024 MiB = 2**30 bytes.
 
 How it works
 ------------

--- a/docs/topics/advanced_topics.rst
+++ b/docs/topics/advanced_topics.rst
@@ -128,13 +128,13 @@ Input sizes
 ===========
 
 Resource requirements are commonly calculated from the size of a job's inputs. The `input_size` context variable
-provides the total size in gigabytes of all of a job's inputs, and the `helpers.get_input_size` function provides
+provides the total size in gibibytes of all of a job's inputs, and the `helpers.get_input_size` function provides
 more control over how that total is arrived at, as introduced in :doc:`tpv_by_example`.
 
 Arguments
 ---------
 
-`get_input_size` returns a size in gigabytes, and accepts the following arguments:
+`get_input_size` returns a size in gibibytes, and accepts the following arguments:
 
 +----------------------------+----------------------------------------------------------------------------+
 | Argument                   | Description                                                                |
@@ -296,8 +296,8 @@ Mapped fields are:
 
 * ``cores_min`` -> ``cores``
 * ``cores_max`` -> ``max_cores``
-* ``ram_min`` -> ``mem`` (converted from mebibytes to GB)
-* ``ram_max`` -> ``max_mem`` (converted from mebibytes to GB)
+* ``ram_min`` -> ``mem`` (converted from mebibytes to GiB)
+* ``ram_max`` -> ``max_mem`` (converted from mebibytes to GiB)
 * ``cuda_device_count_min`` -> ``gpus``
 * ``cuda_device_count_max`` -> ``max_gpus``
 
@@ -305,8 +305,8 @@ If the same resource is also defined in TPV ``tools:``, the TPV configuration va
 auto-injected value.
 
 Galaxy expresses ``ram_min`` and ``ram_max`` in mebibytes (2**20 bytes), whereas TPV's ``mem`` and
-``max_mem`` are in GB, so the values are divided by 1024 when injected. A tool declaring ``ram_min=16384``
-is injected as ``mem: 16``.
+``max_mem`` are in gibibytes (GiB, 2**30 bytes), so the values are divided by 1024 when injected.
+A tool declaring ``ram_min=16384`` is injected as ``mem: 16``.
 
 For example, with a tool that declares ``cores_min=8`` and ``ram_min=16384`` in Galaxy's tool XML:
 
@@ -315,7 +315,7 @@ For example, with a tool that declares ``cores_min=8`` and ``ram_min=16384`` in 
 
    tools:
      default:
-      mem: 8  # The Galaxy tool wrapper's ram_min (16384 MiB -> 16 GB) would override this default value
+      mem: 8  # The Galaxy tool wrapper's ram_min (16384 MiB -> 16 GiB) would override this default value
      my_tool:
        mem: 32  # but this specific override takes priority over ram_min
    destinations:
@@ -361,13 +361,13 @@ that can be used in rules, rank functions, params, and other code blocks.
 | ``sampling(destinations)``         | destination's optional ``params.weight`` value. Used in rank functions   |
 |                                    | to break ties or provide a fallback when load-based ranking fails.       |
 +------------------------------------+--------------------------------------------------------------------------+
-| ``helpers.weighted_choice(items)`` | Selects one item from a weighted pool of ``{value, weight}`` dicts and    |
-|                                    | returns the chosen dict, mirroring ``random.choice``. Use               |
+| ``helpers.weighted_choice(items)`` | Selects one item from a weighted pool of ``{value, weight}`` dicts and   |
+|                                    | returns the chosen dict, mirroring ``random.choice``. Use                |
 |                                    | ``helpers.weighted_choice(items)["value"]`` when you need the underlying |
 |                                    | string. Primary use case is distributing jobs across multiple job        |
 |                                    | working directory roots. See the recipe in :doc:`tpv_by_example`.        |
 +------------------------------------+--------------------------------------------------------------------------+
-| ``helpers.input_size(job)``        | Returns the total input dataset size in GB for the given job.            |
+| ``helpers.input_size(job)``        | Returns the total input dataset size in GiB for the given job.           |
 +------------------------------------+--------------------------------------------------------------------------+
 | ``helpers.concurrent_job_count_``  | Returns the number of queued/running jobs for the given tool (and        |
 | ``for_tool(app, tool, user)``      | optional user). Useful for limiting concurrent executions per tool.      |

--- a/docs/topics/advanced_topics.rst
+++ b/docs/topics/advanced_topics.rst
@@ -296,13 +296,17 @@ Mapped fields are:
 
 * ``cores_min`` -> ``cores``
 * ``cores_max`` -> ``max_cores``
-* ``ram_min`` -> ``mem``
-* ``ram_max`` -> ``max_mem``
+* ``ram_min`` -> ``mem`` (converted from mebibytes to GB)
+* ``ram_max`` -> ``max_mem`` (converted from mebibytes to GB)
 * ``cuda_device_count_min`` -> ``gpus``
 * ``cuda_device_count_max`` -> ``max_gpus``
 
 If the same resource is also defined in TPV ``tools:``, the TPV configuration value overrides the
 auto-injected value.
+
+Galaxy expresses ``ram_min`` and ``ram_max`` in mebibytes (2**20 bytes), whereas TPV's ``mem`` and
+``max_mem`` are in GB, so the values are divided by 1024 when injected. A tool declaring ``ram_min=16384``
+is injected as ``mem: 16``.
 
 For example, with a tool that declares ``cores_min=8`` and ``ram_min=16384`` in Galaxy's tool XML:
 
@@ -311,14 +315,14 @@ For example, with a tool that declares ``cores_min=8`` and ``ram_min=16384`` in 
 
    tools:
      default:
-      mem: 8  # The Galaxy tool wrapper's ram_min would override this default value
+      mem: 8  # The Galaxy tool wrapper's ram_min (16384 MiB -> 16 GB) would override this default value
      my_tool:
        mem: 32  # but this specific override takes priority over ram_min
    destinations:
      slurm:
        runner: slurm
        max_accepted_cores: 16
-       max_accepted_mem: 32768
+       max_accepted_mem: 32
 
 Note that tool resource requirements override tool defaults.
 

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -220,7 +220,7 @@ Rules provide a means by which to conditionally change entity requirements.
        rules:
          - id: my_overridable_rule
            if: input_size < 5
-           fail: We don't run piddling datasets of {input_size}GB
+           fail: We don't run piddling datasets of {input_size}GiB
      bwa:
        scheduling:
          require:
@@ -277,7 +277,7 @@ recorded for a compressed dataset is its size on disk. The `helpers.get_input_si
        mem: min(max(int(helpers.get_input_size(job, "library|input_1") * 4), 8), 128)
 
 In this example, only the reads input of the hisat2 tool is sized, ignoring any other inputs the job may have, and
-the tool is allocated 4GB of memory per gigabyte of reads, clamped to between 8GB and 128GB. Since the reads are
+the tool is allocated 4GiB of memory per gibibyte of reads, clamped to between 8GiB and 128GiB. Since the reads are
 typically compressed, and the estimate must be based on their uncompressed size, their recorded size is first
 multiplied by 3.4.
 
@@ -570,7 +570,7 @@ that do not require the full core allocation. Conversely, some users can be allo
 `min_cores`.
 
 In addition, clamping resources can also be useful when using the TPV shared database. For example, the `canu` tool
-has a 96GB recommended memory requirement, which your local cluster may not have. However, you may still want to allow
+has a 96GiB recommended memory requirement, which your local cluster may not have. However, you may still want to allow
 the tool to run, albeit with lower resources. You can of course, locally override the `canu` tool and allocated less
 resources, but this can be tedious to do for a large number of tools. All you may really want, is to restrict all
 tools to use the maximum your cluster can support. You can achieve that effect as follows:
@@ -590,9 +590,9 @@ tools to use the maximum your cluster can support. You can achieve that effect a
        max_gpus: 1
 
 
-In the example above, we mark the slurm destination as accepting jobs up to 196GB in size, and therefore, the
-`canu` tool, which required 96GB, would successfully schedule there. However, we forcibly clamp the job's max_mem
-to 64GB, which is the actual memory your cluster can support. In this way, all tools in the shared
+In the example above, we mark the slurm destination as accepting jobs up to 196GiB in size, and therefore, the
+`canu` tool, which required 96GiB, would successfully schedule there. However, we forcibly clamp the job's max_mem
+to 64GiB, which is the actual memory your cluster can support. In this way, all tools in the shared
 database can still run, provided they do not exceed the specified `max_accepted` values.
 
 Giving a parameterized, custom name to a destination

--- a/tests/fixtures/scenario-trinity-job-too-much-data.yml
+++ b/tests/fixtures/scenario-trinity-job-too-much-data.yml
@@ -51,7 +51,7 @@ tools:
           require:
             - highmem
       - if: input_size >= 200
-        fail: "Input file size of {input_size}GB is > maximum allowed 200GB limit"
+        fail: "Input file size of {input_size}GiB is > maximum allowed 200GiB limit"
 destinations:
   slurm:
     runner: slurm

--- a/tests/test_mapper_context.py
+++ b/tests/test_mapper_context.py
@@ -44,7 +44,7 @@ class TestMapperContext(unittest.TestCase):
         self.assertEqual(destination.params["native_spec"], "--mem 15 --cores 5 --gpus 4")
 
     def test_context_variable_overridden_in_rule(self):
-        # test that job will not fail with 40GB input size because large_input_size has been set to 60
+        # test that job will not fail with 40GiB input size because large_input_size has been set to 60
         tool = mock_galaxy.Tool("bwa")
         user = mock_galaxy.User("gargravarr", "fairycake@vortex.org")
         datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=40 * 1024**3))]

--- a/tests/test_mapper_resource_requirements.py
+++ b/tests/test_mapper_resource_requirements.py
@@ -48,11 +48,20 @@ class TestMapperResourceRequirements(unittest.TestCase):
         self.assertEqual(result, {"cores": 4})
 
     def test_extract_resource_requirements_from_tool_memory(self):
+        # Galaxy ram_min is in mebibytes, TPV mem is in GB
         mem_req = ResourceRequirement("8192", "ram_min")
 
         tool = mock_galaxy.Tool("test_tool", resource_requirements=[mem_req])
         result = extract_resource_requirements_from_tool(tool)
-        self.assertEqual(result, {"mem": 8192})
+        self.assertEqual(result, {"mem": 8})
+
+    def test_extract_resource_requirements_from_tool_memory_fractional(self):
+        # Galaxy's default ram_min for a resource requirement block is 256 MiB
+        mem_req = ResourceRequirement("256", "ram_min")
+
+        tool = mock_galaxy.Tool("test_tool", resource_requirements=[mem_req])
+        result = extract_resource_requirements_from_tool(tool)
+        self.assertEqual(result, {"mem": 0.25})
 
     def test_extract_resource_requirements_from_tool_gpus(self):
         gpu_req = ResourceRequirement("2", "cuda_device_count_min")
@@ -68,7 +77,7 @@ class TestMapperResourceRequirements(unittest.TestCase):
 
         tool = mock_galaxy.Tool("test_tool", resource_requirements=[cores_req, mem_req, gpu_req])
         result = extract_resource_requirements_from_tool(tool)
-        expected = {"cores": 4, "mem": 16384, "gpus": 1}
+        expected = {"cores": 4, "mem": 16, "gpus": 1}
         self.assertEqual(result, expected)
 
     def test_extract_resource_requirements_with_not_implemented_error(self):
@@ -126,7 +135,7 @@ class TestMapperResourceRequirements(unittest.TestCase):
 
     def test_default_entity_creation_with_resource_requirements(self):
         cores_req = ResourceRequirement("2", "cores_min")
-        ram_min_req = ResourceRequirement("12", "ram_min")
+        ram_min_req = ResourceRequirement("12288", "ram_min")
 
         tool = mock_galaxy.Tool("nonexistent_tool", resource_requirements=[cores_req, ram_min_req])
         user = mock_galaxy.User("test_user", "test@test.com")
@@ -147,12 +156,12 @@ class TestMapperResourceRequirements(unittest.TestCase):
             "test_tool", resource_requirements=[cores_min_req, cores_max_req, ram_min_req, ram_max_req]
         )
         result = extract_resource_requirements_from_tool(tool)
-        expected = {"cores": 2, "max_cores": 8, "mem": 4096, "max_mem": 32768}
+        expected = {"cores": 2, "max_cores": 8, "mem": 4, "max_mem": 32}
         self.assertEqual(result, expected)
 
     def test_default_entity_creation_overrides_resource_requirements(self):
         cores_req = ResourceRequirement("3", "cores_min")
-        mem_req = ResourceRequirement("8", "ram_min")
+        mem_req = ResourceRequirement("8192", "ram_min")
         gpu_req = ResourceRequirement("2", "cuda_device_count_min")
 
         tool = mock_galaxy.Tool("nonexistent_tool", resource_requirements=[cores_req, mem_req, gpu_req])

--- a/tests/test_mapper_resource_requirements.py
+++ b/tests/test_mapper_resource_requirements.py
@@ -48,7 +48,7 @@ class TestMapperResourceRequirements(unittest.TestCase):
         self.assertEqual(result, {"cores": 4})
 
     def test_extract_resource_requirements_from_tool_memory(self):
-        # Galaxy ram_min is in mebibytes, TPV mem is in GB
+        # Galaxy ram_min is in mebibytes, TPV mem is in GiB
         mem_req = ResourceRequirement("8192", "ram_min")
 
         tool = mock_galaxy.Tool("test_tool", resource_requirements=[mem_req])

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -150,7 +150,7 @@ class TestScenarios(unittest.TestCase):
     @responses.activate
     def test_scenario_trinity_job_too_much_data(self):
         """
-        Contextual fail message sent to user with reasons that there is too much data. (i.e. that 1TB is > 200GB)
+        Contextual fail message sent to user with reasons that there is too much data. (i.e. that 1000GiB is > 200GiB)
         """
         responses.add(
             method=responses.GET,
@@ -172,7 +172,7 @@ class TestScenarios(unittest.TestCase):
         rules_file = os.path.join(os.path.dirname(__file__), "fixtures/scenario-trinity-job-too-much-data.yml")
         with self.assertRaisesRegex(
             JobMappingException,
-            "Input file size of 1000.0GB is > maximum allowed 200GB limit",
+            "Input file size of 1000.0GiB is > maximum allowed 200GiB limit",
         ):
             self._map_to_destination(
                 tool,

--- a/tpv/commands/shell.py
+++ b/tpv/commands/shell.py
@@ -156,7 +156,7 @@ def create_parser() -> argparse.ArgumentParser:
         "dry-run", help="Perform a dry run test of a TPV configuration.", description=""
     )
     dry_run_parser.add_argument("--job-conf", type=str, required=True, help="Galaxy job configuration file")
-    dry_run_parser.add_argument("--input-size", type=int, help="Input dataset size (in GB)")
+    dry_run_parser.add_argument("--input-size", type=int, help="Input dataset size (in GiB)")
     dry_run_parser.add_argument(
         "--tool",
         type=str,

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -24,6 +24,7 @@ from galaxy.tools import Tool as GalaxyTool
 from tpv.core.entities import Destination, Entity
 from tpv.core.resource_requirements import TPVResourceFieldName, extract_resource_requirements_from_tool
 
+# Bytes per GiB; retain the historical name for existing TPV rules.
 GIGABYTES = 1024.0**3
 
 # Datatype extension suffixes that indicate a compressed dataset, e.g. `fastqsanger.gz`
@@ -110,7 +111,7 @@ def get_input_size(
     compression_factor: float = DEFAULT_COMPRESSION_FACTOR,
 ) -> float:
     """
-    Return the total size in gigabytes of a job's input datasets.
+    Return the total size in gibibytes of a job's input datasets.
 
     If `param_name` is given, only the datasets recorded for that tool parameter are totalled,
     otherwise all of the job's input datasets are. Compressed inputs are multiplied by

--- a/tpv/core/resource_requirements.py
+++ b/tpv/core/resource_requirements.py
@@ -20,6 +20,9 @@ VALID_RESOURCE_TYPES = get_args(ResourceType)
 
 TPVResourceFieldName = Literal["cores", "max_cores", "mem", "max_mem", "gpus", "max_gpus"]
 
+# Galaxy's ``ram_min``/``ram_max`` resource requirements are in mebibytes (2**20 bytes), TPV's ``mem`` is in GB.
+MEBIBYTES_PER_GB = 1024
+
 
 class TPVResourceFields(TypedDict, total=False):
     """Type definition for TPV entity resource fields that can be extracted from Galaxy tools."""
@@ -70,6 +73,9 @@ def extract_resource_requirements_from_tool(
                 # but interface on galaxy side not yet implemented.
                 value = resource_req.get_value()
                 if value is not None:
+                    if resource_req.resource_type in ("ram_min", "ram_max"):
+                        # Galaxy (following CWL) expresses RAM in mebibytes, TPV expresses mem in GB.
+                        value = value / MEBIBYTES_PER_GB
                     extracted[tpv_field] = value  # type: ignore[literal-required]
             except NotImplementedError:
                 # Skip expression evaluation for now

--- a/tpv/core/resource_requirements.py
+++ b/tpv/core/resource_requirements.py
@@ -20,8 +20,8 @@ VALID_RESOURCE_TYPES = get_args(ResourceType)
 
 TPVResourceFieldName = Literal["cores", "max_cores", "mem", "max_mem", "gpus", "max_gpus"]
 
-# Galaxy's ``ram_min``/``ram_max`` resource requirements are in mebibytes (2**20 bytes), TPV's ``mem`` is in GB.
-MEBIBYTES_PER_GB = 1024
+# Galaxy's ``ram_min``/``ram_max`` resource requirements are in mebibytes (2**20 bytes), TPV's ``mem`` is in GiB.
+MEBIBYTES_PER_GIB = 1024
 
 
 class TPVResourceFields(TypedDict, total=False):
@@ -74,8 +74,8 @@ def extract_resource_requirements_from_tool(
                 value = resource_req.get_value()
                 if value is not None:
                     if resource_req.resource_type in ("ram_min", "ram_max"):
-                        # Galaxy (following CWL) expresses RAM in mebibytes, TPV expresses mem in GB.
-                        value = value / MEBIBYTES_PER_GB
+                        # Galaxy (following CWL) expresses RAM in mebibytes, TPV expresses mem in GiB.
+                        value = value / MEBIBYTES_PER_GIB
                     extracted[tpv_field] = value  # type: ignore[literal-required]
             except NotImplementedError:
                 # Skip expression evaluation for now


### PR DESCRIPTION
Galaxy (following CWL) expresses `ram_min` and `ram_max` in mebibytes (MiB), while TPV's `mem` and `max_mem` are in gibibytes (GiB). Auto-injected tool resource requirements previously copied the raw value, so a tool declaring `ram_min: 8192` requested 8192 GiB instead of 8 GiB. Convert both memory fields by dividing by 1024.

This also fixes user-defined tools with a `type: resource` block: Galaxy stores the default `ram_min: 256`, which should request 0.25 GiB instead of 256 GiB and avoid incorrectly exceeding destination memory limits.

Correct GB/gigabyte terminology throughout the documentation, CLI help, comments, and example messages to GiB/gibibyte, matching TPV's existing binary units. Document the unit convention explicitly and fix the helper table formatting so the corrected input-size documentation renders.

Validation: all 252 tests pass on Python 3.10 (including slow tests), lint and mypy pass, and the Sphinx HTML build completes with only pre-existing diagnostics (14, down from 15).
