### PR TITLE
Fix Sphinx documentation errors and warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ release = tpv.get_version()
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/topics/advanced_topics.rst
+++ b/docs/topics/advanced_topics.rst
@@ -357,8 +357,8 @@ that can be used in rules, rank functions, params, and other code blocks.
 | ``sampling(destinations)``         | destination's optional ``params.weight`` value. Used in rank functions   |
 |                                    | to break ties or provide a fallback when load-based ranking fails.       |
 +------------------------------------+--------------------------------------------------------------------------+
-| ``helpers.weighted_choice(items)`` | Selects one item from a weighted pool of ``{value, weight}`` dicts and    |
-|                                    | returns the chosen dict, mirroring ``random.choice``. Use               |
+| ``helpers.weighted_choice(items)`` | Selects one item from a weighted pool of ``{value, weight}`` dicts and   |
+|                                    | returns the chosen dict, mirroring ``random.choice``. Use                |
 |                                    | ``helpers.weighted_choice(items)["value"]`` when you need the underlying |
 |                                    | string. Primary use case is distributing jobs across multiple job        |
 |                                    | working directory roots. See the recipe in :doc:`tpv_by_example`.        |

--- a/docs/topics/faq.rst
+++ b/docs/topics/faq.rst
@@ -6,19 +6,19 @@ FAQ
 
    You can simply import the logging module within a code block. For example:
 
-.. code-block:: yaml
-:linenos:
+   .. code-block:: yaml
+      :linenos:
 
-tools:
-    default:
-    cores: 2
-    mem: cores * 3
-    rules:
-        - if: True
-          execute: |
-            import logging
-            log = logging.getLogger(__name__)
-            log.debug(f"Here's what the entity looks like: {entity}")
+      tools:
+          default:
+              cores: 2
+              mem: cores * 3
+              rules:
+                  - if: True
+                    execute: |
+                      import logging
+                      log = logging.getLogger(__name__)
+                      log.debug(f"Here's what the entity looks like: {entity}")
 
 
 2. How can I import custom libraries or code?
@@ -26,15 +26,15 @@ tools:
    As long as the code is available within Galaxy's virtualenv or the python path,
    it can be imported like any other package. For example:
 
-.. code-block:: yaml
-:linenos:
+   .. code-block:: yaml
+      :linenos:
 
-tools:
-    default:
-    cores: 2
-    mem: cores * 3
-    rules:
-        - if: True
-          execute: |
-            import my_custom_module
-            my_custom_module.my_func()
+      tools:
+          default:
+              cores: 2
+              mem: cores * 3
+              rules:
+                  - if: True
+                    execute: |
+                      import my_custom_module
+                      my_custom_module.my_func()

--- a/docs/topics/installation.rst
+++ b/docs/topics/installation.rst
@@ -48,7 +48,7 @@ TPV allows rules to be loaded from remote or local sources.
 
 .. code-block:: yaml
    :linenos:
-   :emphasize-lines: 7-9,14-19
+   :emphasize-lines: 6-8
 
    tpv_dispatcher:
     runner: dynamic

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -445,7 +445,7 @@ tools to conveniently override values, even across files. While this capability 
 treated with the same care as any global variable in a programming language.
 
 Multiple matches
----------------
+----------------
 If multiple regular expressions match, the matches are applied in order of appearance. Therefore, the convention is
 to specify more general rule matches first, and more specific matches later. This matching also applies across
 multiple TPV config files, again based on order of appearance.
@@ -548,7 +548,7 @@ as follows:
 
 .. code-block:: yaml
    :linenos:
-   :emphasize-lines: 7-9,14-19
+   :emphasize-lines: 6-8
 
    tpv_dispatcher:
      runner: dynamic
@@ -577,7 +577,7 @@ tools to use the maximum your cluster can support. You can achieve that effect a
 
 .. code-block:: yaml
    :linenos:
-   :emphasize-lines: 7-9,14-19
+   :emphasize-lines: 7-9
 
    destinations:
      slurm:

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -649,6 +649,8 @@ helper falls back to an unweighted random selection so the configuration always
 resolves.
 
 This recipe requires Galaxy's ``job_working_directory`` job-concern support
-(Galaxy PR :issue:`23133` / :issue:`15616` / :issue:`20062`).  Without that
+(Galaxy PR `23133 <https://github.com/galaxyproject/galaxy/pull/23133>`_ /
+`15616 <https://github.com/galaxyproject/galaxy/pull/15616>`_ /
+`20062 <https://github.com/galaxyproject/galaxy/pull/20062>`_).  Without that
 change, the param is still set by TPV but Galaxy will use the object-store
 derived path instead.


### PR DESCRIPTION
A fresh Sphinx build of main reports 15 diagnostics, including a malformed helper table, incorrectly nested FAQ code blocks, undefined `issue` roles, and invalid highlight ranges. These repairs allow a strict HTML build to complete without warnings or errors.

- Align two existing helper-table borders.
- Nest the FAQ code blocks under their questions and place `cores`, `mem`, and `rules` inside `tools.default`.
- Replace the three undefined roles with explicit Galaxy pull-request links.
- Set the documentation language to English, fix the “Multiple matches” underline, and highlight valid config-file and resource-limit lines.

Validation: reproduced the baseline failures, then passed a fresh Sphinx 9.1.0 build with `-E -a -W --keep-going -b html`. Checked the affected HTML sections, parsed both FAQ YAML samples and checked their embedded Python syntax. Repository hooks and `git diff --check` pass.
